### PR TITLE
Implemented Function to Extract Project id from Query String and Hash

### DIFF
--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Classroom Page</title>
+</head>
+
+<body>
+    <h1>Classroom Group Management</h1>
+    <p id="project-info">Project ID: </p>
+
+
+    <script src="project.js"></script>
+
+    <script>
+        // Call the function to get the ProjectID and display it
+        const projectID = getProjectIDFromURL();
+        if (projectID) {
+            document.getElementById('project-info').textContent = 'Project ID: ' + projectID;
+        } else {
+            document.getElementById('project-info').textContent = 'Project ID not found in URL';
+        }
+    </script>
+</body>
+
+</html>
+

--- a/components/classroom/project.js
+++ b/components/classroom/project.js
@@ -1,0 +1,16 @@
+// function extracts projectID from URL of the page
+function getProjectIDFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    let projectId = params.get('projectId');
+    console.log(projectId); 
+
+    if (!projectId) {
+        const hash = window.location.hash;
+        projectId = hash.substring(1); 
+        console.log(projectId);
+        return projectId
+    }
+    else {
+        return projectId
+    }
+}


### PR DESCRIPTION
Fixes #1

What was changed:
- Created the `getProjectIDFromURL` function to correctly handle cases where projectId is either in the query string or the hash.
- Added an HTML page to display the project Id or indicate when no project Id is found.

Why was it changed:
- No previous implementation of extracting project ID before existed.

How was it changed:
- The function first checks the query string for the project Id.
- If the project Id is not found in the query string, it checks the hash.
- Added an `index.html` file to provide a structure for the function to run.

