### PR TITLE
Relative Selectors

### DIFF
--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -320,24 +320,59 @@ class AnnotoriousAnnotator extends HTMLElement {
     }
 
     /**
+      * Adjust Annotation selectors as needed for communication between Annotorious and TPEN3.
+      * Annotorious naturally builds selector values relative to image dimensions.
+      * TPEN3 wants them relative to Canvas dimensions.
+      * When recieving Annotations to render convert the selectors so they are relative to the image and draw correctly.
+      * When saving Annotations convert the selectors so they are relative to the canvas and save correctly.
+    */
+    convertSelectors(annotations, bool=false) {
+      let orig_xywh, converted_xywh = []
+      let tar, sel = ""
+      return annotations.map(annotation => {
+        if(bool) {
+          /**
+           * You are converting for Annotorious.  Selectors need to be changed to be relative to the Image dimensions.
+           * This is so that they render correctly.  TPEN3 selectors are relative to the Canvas dimensions.
+          */
+          tar = annotation.target.split("#xywh=")[0]
+          orig_xywh = annotation.target.split("#xywh=")[1].split(",")
+          converted_xywh[0] = parseInt((this.#imageDims[0] / this.#canvasDims[0]) * parseInt(orig_xywh[0]))
+          converted_xywh[1] = parseInt((this.#imageDims[1] / this.#canvasDims[1]) * parseInt(orig_xywh[1]))
+          converted_xywh[2] = parseInt((this.#imageDims[0] / this.#canvasDims[0]) * parseInt(orig_xywh[2]))
+          converted_xywh[3] = parseInt((this.#imageDims[1] / this.#canvasDims[1]) * parseInt(orig_xywh[3]))
+
+          // FIXME this results in a slight visual overlap of lines even though it should not.
+          sel = "#xywh=" + converted_xywh.join(",")
+          annotation.target = tar + sel
+        }
+        else{
+          /**
+           * You are converting for TPEN3.  Selectors need to be changed to be relative to the Canvas dimensions.
+           * This is so that they save correctly.  Annotorious selectors are relative to the Image dimensions.
+          */
+          tar = annotation.target.source
+          orig_xywh = annotation.target.selector.value.replace("xywh=pixel:", "").split(",")
+          converted_xywh[0] = parseInt((this.#canvasDims[0] / this.#imageDims[0]) * parseInt(orig_xywh[0]))
+          converted_xywh[1] = parseInt((this.#canvasDims[1] / this.#imageDims[1]) * parseInt(orig_xywh[1]))
+          converted_xywh[2] = parseInt((this.#canvasDims[0] / this.#imageDims[0]) * parseInt(orig_xywh[2]))
+          converted_xywh[3] = parseInt((this.#canvasDims[1] / this.#imageDims[1]) * parseInt(orig_xywh[3]))
+          sel = "xywh=" + converted_xywh.join(",")
+          annotation.target.selector.value = sel
+        }
+        return annotation
+      })
+    }
+
+    /**
      * Format and pass along the Annotations from the provided AnnotationPage.
      * Annotorious will render them on screen and introduce them to the UX flow.
-     *
-     * FIXME Annotorious does not draw Annotations correctly when the canvas and image dimensions are different.
-     *
-     * DEMO for FIXME
-     * Note that the Canvas in the "wonky" data is exactly half the size of the Canvas in the "normal" data.
-     * Note that the width and the height of the Canvas were used to determine the fragment selector #xywh values in another platform.
-     *
-     * Normal behavior use ?pageID=https://tpen-project-examples.habesoftware.app/transcription-project/page-1.json
-     * Wonky Behavior use ?pageID=https://store.rerum.io/v1/id/67e55afd4850bf3e0edee32f
-     *
-     * Note that the target values for those AnnotationPages are the Canvases, where you will find the width and height.
-     * 
     */
     setInitialAnnotations() {
       if(!this.#resolvedAnnotationPage) return
       let allAnnotations = JSON.parse(JSON.stringify(this.#resolvedAnnotationPage.items))
+      // Convert the Annotation selectors so that they are relative to the Image dimensions
+      allAnnotations = this.convertSelectors(allAnnotations, true)
       allAnnotations.map(annotation => {
         annotation.body = [annotation.body]
         const tarsel = annotation.target.split("#")
@@ -359,28 +394,11 @@ class AnnotoriousAnnotator extends HTMLElement {
       * This page renders because of a known AnnotationPage.  Existing Annotations in that AnnotationPage were drawn.
       * There have been edits to the page items and those edits need to be saved.
       * Announce the AnnotationPage with the changes that needs to be updated for processing upstream.
-      * 
-      * Note that Annotorious has opinions about Annotation body and target values.  So does TPEN3.
-      * TPEN3 opinions are preferenced.
-      *
-      * FIXME Annotorious disregards the Canvas width and height when making #xywh FragmentSelectors.
-      * Instead, tt uses the Image width and height to determine the values of the #xywh selectors.
-      *
-      * DEMO
-      * Note the only difference in the Canvases are the recorded width and height for the Canvas.
-      *
-      * Normal behavior use ?pageID=https://tpen-project-examples.habesoftware.app/transcription-project/page-1.json
-      * Draw some Annotations and save them to see the fragment selector values generated for the Annotations.
-      *
-      * Wonky Behavior use ?pageID=https://store.rerum.io/v1/id/67e55afd4850bf3e0edee32f
-      * Draw some Annotations and save them to see the fragment selector values generated for the Annotations.
-      * The Annotations will have the same target selectors even though this Canvas is half the size of the other.
-      * This is because it used the Image Dimensions to determine the selectors as opposed to the Canvas Dimensions.
-      *
-      * Note that the target values for those AnnotationPages are the Canvases, where you will find the width and height.
     */
     saveAnnotations() {
       let allAnnotations = this.#annotoriousInstance.getAnnotations()
+      // Convert the Annotation selectors so that they are relative to the Canvas dimensions
+      allAnnotations = this.convertSelectors(allAnnotations, false)
       allAnnotations = allAnnotations.map(annotation => {
         annotation.body = annotation.body.length ? annotation.body[0] : {}
         const tar = annotation.target.source

--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -349,8 +349,6 @@ class AnnotoriousAnnotator extends HTMLElement {
           converted_xywh[1] = parseInt((this.#imageDims[1] / this.#canvasDims[1]) * parseInt(orig_xywh[1]))
           converted_xywh[2] = parseInt((this.#imageDims[0] / this.#canvasDims[0]) * parseInt(orig_xywh[2]))
           converted_xywh[3] = parseInt((this.#imageDims[1] / this.#canvasDims[1]) * parseInt(orig_xywh[3]))
-
-          // FIXME this results in a slight visual overlap of lines even though it should not.
           sel = "#xywh=" + converted_xywh.join(",")
           annotation.target = tar + sel
         }

--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -325,15 +325,23 @@ class AnnotoriousAnnotator extends HTMLElement {
       * TPEN3 wants them relative to Canvas dimensions.
       * When recieving Annotations to render convert the selectors so they are relative to the image and draw correctly.
       * When saving Annotations convert the selectors so they are relative to the canvas and save correctly.
+      *
+      * @param annotations - An Array of Annotations whose selectors need converted
+      * @param bool - A switch for forwards or backwards conversion
+      *
+      * @return the Array of Annotations with their selectors converted
     */
     convertSelectors(annotations, bool=false) {
+      if(!annotations || annotations.length === 0) return
       let orig_xywh, converted_xywh = []
       let tar, sel = ""
       return annotations.map(annotation => {
+        if(!annotation.target) return
         if(bool) {
           /**
            * You are converting for Annotorious.  Selectors need to be changed to be relative to the Image dimensions.
            * This is so that they render correctly.  TPEN3 selectors are relative to the Canvas dimensions.
+           * The target is in simplified TPEN3 format. uri#xywh=
           */
           tar = annotation.target.split("#xywh=")[0]
           orig_xywh = annotation.target.split("#xywh=")[1].split(",")
@@ -350,6 +358,7 @@ class AnnotoriousAnnotator extends HTMLElement {
           /**
            * You are converting for TPEN3.  Selectors need to be changed to be relative to the Canvas dimensions.
            * This is so that they save correctly.  Annotorious selectors are relative to the Image dimensions.
+           * The target is in expanded Annotatorious format. {source:"uri", selector:{value:"xywh="}}
           */
           tar = annotation.target.source
           orig_xywh = annotation.target.selector.value.replace("xywh=pixel:", "").split(",")

--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -332,11 +332,12 @@ class AnnotoriousAnnotator extends HTMLElement {
       * @return the Array of Annotations with their selectors converted
     */
     convertSelectors(annotations, bool=false) {
-      if(!annotations || annotations.length === 0) return
+      if(this.#imageDims[0] === this.#canvasDims[0] && this.#imageDims[1] === this.#canvasDims[1]) return annotations
+      if(!annotations || annotations.length === 0) return annotations
       let orig_xywh, converted_xywh = []
       let tar, sel = ""
       return annotations.map(annotation => {
-        if(!annotation.target) return
+        if(!annotation.target) return annotation
         if(bool) {
           /**
            * You are converting for Annotorious.  Selectors need to be changed to be relative to the Image dimensions.
@@ -358,7 +359,6 @@ class AnnotoriousAnnotator extends HTMLElement {
            * This is so that they save correctly.  Annotorious selectors are relative to the Image dimensions.
            * The target is in expanded Annotorious format. {source:"uri", selector:{value:"xywh="}}
           */
-          tar = annotation.target.source
           orig_xywh = annotation.target.selector.value.replace("xywh=pixel:", "").split(",")
           converted_xywh[0] = parseInt((this.#canvasDims[0] / this.#imageDims[0]) * parseInt(orig_xywh[0]))
           converted_xywh[1] = parseInt((this.#canvasDims[1] / this.#imageDims[1]) * parseInt(orig_xywh[1]))

--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -356,7 +356,7 @@ class AnnotoriousAnnotator extends HTMLElement {
           /**
            * You are converting for TPEN3.  Selectors need to be changed to be relative to the Canvas dimensions.
            * This is so that they save correctly.  Annotorious selectors are relative to the Image dimensions.
-           * The target is in expanded Annotatorious format. {source:"uri", selector:{value:"xywh="}}
+           * The target is in expanded Annotorious format. {source:"uri", selector:{value:"xywh="}}
           */
           tar = annotation.target.source
           orig_xywh = annotation.target.selector.value.replace("xywh=pixel:", "").split(",")


### PR DESCRIPTION
Convert Annotation selectors on their way into and out of the Annotorious Annotator interface.  This is so that when Annotations are saved, their selectors are relative to the Canvas dimension as per the IIIF Presentation API spec.  

It also makes sure that when Annotations are supplied to Annotorious their selectors are relative to the Image dimensions for accurate renderings as per the Annotorious API spec.

This does nothing to help the overall issue that the specs should not be expecting different things.

Test the interface with these three links

1. /interfaces/annotator/?pageID=https://tpen-project-examples.habesoftware.app/transcription-project/page-1.json
2. /interfaces/annotator/?pageID=https://store.rerum.io/v1/id/67e55bff9f8a7211bec9919b
3. /interfaces/annotator/?pageID=https://store.rerum.io/v1/id/67ec31b39f8a7211bec992c4

The URIs provided are AnnotationPages.  Each AnnotationPage targets its own Canvas.  Each Canvas has the same image.  Annotations are all attempting to target the same areas of interest.

1. The target Canvas has the same dimensions as the Image on the Canvas.
2. The target Canvas is exactly half the dimensions of the Image on the Canvas.
3. The target Canvas is exactly twice the dimensions of the Image on the Canvas.

You will see them all render accurately.  You may also choose to make another Annotation and click "save annotations".  All Annotations will be logged in the console and you can see their selectors to make sure they are all alike.
