### PR TITLE
Add permission check to SplitscreenTool rendering

### DIFF
--- a/components/splitscreen-tool/index.js
+++ b/components/splitscreen-tool/index.js
@@ -1,3 +1,7 @@
+import "../check-permissions/checkPermissions.js"
+import TPEN from "../../api/TPEN.js"
+const eventDispatcher = TPEN.eventDispatcher
+
 export default class SplitscreenTool extends HTMLElement {
     constructor() {
       super()
@@ -5,8 +9,15 @@ export default class SplitscreenTool extends HTMLElement {
     }
 
     connectedCallback() {
-      this.render()
-      this.addEventListeners()
+      eventDispatcher.on('tpen-project-loaded', () => {
+        // Only render if the user has view access to the project
+        if (!TPEN.checkPermissions.checkViewAccess('TOOL', 'ANY')) {
+          this.remove()
+          return
+        }
+        this.render()
+        this.addEventListeners()
+      })
     }
 
     addEventListeners() {


### PR DESCRIPTION
SplitscreenTool now listens for the 'tpen-project-loaded' event and only renders if the user has view access to the project. If the user lacks permission, the component is removed from the DOM.