### PR TITLE
Add permission check to split screen component

### DIFF
--- a/components/split-screen/index.js
+++ b/components/split-screen/index.js
@@ -1,3 +1,6 @@
+import "../check-permissions/permission-match.js"
+import TPEN from "../../api/TPEN.js"
+const eventDispatcher = TPEN.eventDispatcher
 export default class TpenSplitScreen extends HTMLElement {
     constructor() {
         super()
@@ -8,8 +11,15 @@ export default class TpenSplitScreen extends HTMLElement {
     }
 
     connectedCallback() {
+      eventDispatcher.on("tpen-project-loaded", () => {
+        if(!CheckPermissions.checkViewAccess("TOOLS", "ANY")) {
+          // No reason to get this far, but let's not risk it.
+          this.remove()
+          return
+        }
         this.render()
         this.addEventListeners()
+      })
     }
 
     addEventListeners() {


### PR DESCRIPTION
Imported permission utilities and added a check in the connectedCallback to ensure the user has view access to TOOLS before rendering the split screen component. The component is removed if the user lacks permission, improving security and user experience.