### PR TITLE
Add permission check for workspace tools visibility

### DIFF
--- a/components/workspace-tools/index.js
+++ b/components/workspace-tools/index.js
@@ -1,3 +1,6 @@
+import TPEN from "../../api/TPEN.js"
+const eventDispatcher = TPEN.eventDispatcher
+import "../check-permissions/checkPermissions.js"
 import "../../components/magnifier-tool/index.js"
 import "../../components/special-character-tool/index.js"
 import "../../components/splitscreen-tool/index.js"
@@ -10,7 +13,14 @@ export default class WorkspaceTools extends HTMLElement {
   }
 
   connectedCallback() {
-    this.render()
+    eventDispatcher.on("tpen-project-loaded", () => {
+      // Check if the user has permission to view workspace tools
+      if (!TPEN.checkPermissions.checkViewAccess("TOOLS", "ANY")) {
+        this.remove()
+        return
+      }
+      this.render()
+    })
   }
 
   render() {

--- a/components/workspace-tools/index.js
+++ b/components/workspace-tools/index.js
@@ -1,6 +1,6 @@
 import TPEN from "../../api/TPEN.js"
 const eventDispatcher = TPEN.eventDispatcher
-import "../check-permissions/checkPermissions.js"
+import CheckPermissions from "../check-permissions/checkPermissions.js"
 import "../../components/magnifier-tool/index.js"
 import "../../components/special-character-tool/index.js"
 import "../../components/splitscreen-tool/index.js"
@@ -15,7 +15,7 @@ export default class WorkspaceTools extends HTMLElement {
   connectedCallback() {
     eventDispatcher.on("tpen-project-loaded", () => {
       // Check if the user has permission to view workspace tools
-      if (!TPEN.checkPermissions.checkViewAccess("TOOLS", "ANY")) {
+      if (!CheckPermissions.checkViewAccess("TOOLS", "ANY")) {
         this.remove()
         return
       }


### PR DESCRIPTION
Workspace tools are now only rendered if the user has permission to view them. The component listens for the 'tpen-project-loaded' event and removes itself if the user lacks the required access.