### PR TITLE
Add permission checks to SpecialCharacterTool components

### DIFF
--- a/components/special-character-tool/index.js
+++ b/components/special-character-tool/index.js
@@ -1,3 +1,8 @@
+import TPEN from "../../api/TPEN"
+import CheckPermissions from "../check-permissions/checkPermissions.js"
+const eventDispatcher = TPEN.eventDispatcher
+import "../check-permissions/permission-match.js"
+
 class SpecialCharacterTool extends HTMLElement {
     constructor() {
         super()
@@ -5,8 +10,14 @@ class SpecialCharacterTool extends HTMLElement {
     }
 
     connectedCallback() {
-        this.render()
-        this.addEventListeners()
+        eventDispatcher.on('tpen-project-loaded', () => {
+            if(!CheckPermissions.checkViewAccess("TOOLS", "ANY")) {
+                this.remove()
+                return
+            }
+            this.render()
+            this.addEventListeners()
+        })
     }
 
     addEventListeners() {
@@ -122,8 +133,14 @@ class SpecialCharacterToolButton extends HTMLElement {
     }
 
     connectedCallback() {
-        this.render()
-        this.addEventListeners()
+        eventDispatcher.on('tpen-project-loaded', () => {
+            if(!CheckPermissions.checkViewAccess("TOOLS", "ANY")) {
+                this.remove()
+                return
+            }
+            this.render()
+            this.addEventListeners()
+        })
     }
 
     addEventListeners() {


### PR DESCRIPTION
SpecialCharacterTool and SpecialCharacterToolButton now check user permissions before rendering, removing themselves if access is denied. This ensures that only authorized users can view and interact with these tools.