### PR TITLE
Add permission check to project header component

### DIFF
--- a/components/projects/project-header.js
+++ b/components/projects/project-header.js
@@ -1,7 +1,7 @@
 import TPEN from "../../api/TPEN.js"
 const eventDispatcher = TPEN.eventDispatcher
 import "../layer-selector/index.js"
-import "../check-permissions/checkPermissions.js"
+import CheckPermissions from "../check-permissions/checkPermissions.js"
 export default class ProjectHeader extends HTMLElement {
     loadFailed = false
 


### PR DESCRIPTION
Imported the checkPermissions module and added a check to ensure the user has view access to the project before rendering the project header. If the user lacks permission, the header is removed from the DOM.