### PR TITLE
Add permission check to MagnifierTool initialization

### DIFF
--- a/components/magnifier-tool/index.js
+++ b/components/magnifier-tool/index.js
@@ -1,3 +1,6 @@
+import TPEN from "../../api/TPEN.js"
+import "../check-permissions/checkPermissions.js"
+
 export default class MagnifierTool extends HTMLElement {
     constructor() {
         super()
@@ -8,8 +11,14 @@ export default class MagnifierTool extends HTMLElement {
     }
 
     connectedCallback() {
-        this.render()
-        this.addEventListeners()
+        TPEN.eventDispatcher.on("tpen-project-loaded", () => {
+            if(!CheckPermissions.checkViewAccess("TOOL", "ANY")) {
+                this.remove()
+            return
+            }
+            this.render()
+            this.addEventListeners()
+        })
     }
 
     addEventListeners() {


### PR DESCRIPTION
MagnifierTool now checks user permissions on 'tpen-project-loaded' before rendering. If the user lacks view access, the tool is removed from the DOM.