### PR TITLE
Layer and Page Management

### DIFF
--- a/components/manage-layers/index.js
+++ b/components/manage-layers/index.js
@@ -193,7 +193,7 @@ class ProjectLayers extends HTMLElement {
         `
         this.shadowRoot.querySelectorAll(".delete-layer").forEach((button) => {
             button.addEventListener("click", (event) => {
-                if (!confirm("This Layer will be delete and the Pages will no longer be a part of this project.  This action cannot be undone.")) return
+                if (!confirm("This Layer will be deleted and the Pages will no longer be a part of this project.  This action cannot be undone.")) return
                 const url = event.target.getAttribute("data-layer-id")
                 const layerId = url.substring(url.lastIndexOf("/") + 1)
 

--- a/components/manage-pages/index.js
+++ b/components/manage-pages/index.js
@@ -172,7 +172,6 @@ class ManagePages extends HTMLElement {
                         labelDiv.classList.add("hidden")
                         editPageLabelButton.classList.add("hidden")
                         
-
                         const labelInput = document.createElement("input")
                         labelInput.type = "text"
                         labelInput.className = "label-input"


### PR DESCRIPTION
Introduce the ability to re-order pages, change page labels, and change layer labels while on the pseudo-interface at /components/manage-layers/index.html

This required substantial changes to TPEN Services.  See https://github.com/CenterForDigitalHumanities/TPEN-services/pull/278