### PR TITLE
Leave Project Component and Interface

### DIFF
--- a/components/decline-project/index.js
+++ b/components/decline-project/index.js
@@ -91,10 +91,11 @@ class DeclineInvite extends HTMLElement {
                 return
             }
             this.shadowRoot.innerHTML = `
-                <h3> 
-                    There was an error declining the invitation.  The message below has more details.
+                <h3>There was an error declining the invitation.</h3>
+                <p>
+                    The message below has more details.
                     Refresh the page to try again or contact the TPEN3 Administrators.  
-                </h3>
+                </p>
                 <code> ${userMessage} <code>
             `
         })

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -1,0 +1,142 @@
+import TPEN from "../../api/TPEN.js"
+import { decodeUserToken } from '../iiif-tools/index.js'
+
+class LeaveProject extends HTMLElement {
+
+    constructor() {
+        super()
+        this.attachShadow({ mode: 'open' })
+    }
+
+    connectedCallback() {
+        TPEN.attachAuthentication(this)
+        this.shadowRoot.innerHTML = `
+            <h3>Loading...</h3>
+        `
+        if (TPEN.activeProject?._id) this.render.bind(this)
+        TPEN.eventDispatcher.on('tpen-project-loaded', this.render.bind(this))
+        TPEN.eventDispatcher.on('tpen-project-load-failed', (err) => {
+            this.shadowRoot.innerHTML = `
+                <h3>Project Error</h3>
+                <p>Could not load project.  The project may not exist at all.</p>
+            `
+        })
+    }
+
+    render() {
+        const agent = decodeUserToken(this.userToken)['http://store.rerum.io/agent']
+        let collaboratorIdList = []
+        let leaderCount = 0
+        for (const key in TPEN.activeProject.collaborators) {
+            collaboratorIdList.push(key)
+            if (TPEN.activeProject.collaborators[key].roles.includes("LEADER")) leaderCount++
+        }
+        if (!agent || !collaboratorIdList.includes(agent.split("/").pop())) {
+            this.shadowRoot.innerHTML = `
+                <h3>User Error</h3>
+                <p>The user agent could not be detected or does not have access to this page.</p>
+            `
+            return
+        }
+        if (TPEN.activeProject.collaborators[agent.split("/").pop()].roles.includes("OWNER")) {
+            this.shadowRoot.innerHTML = `
+                <h3>User Error</h3>
+                <p>You are the owner for this project.  You must transfer ownership before you leave.</p>
+            `
+            return
+        }
+        if (TPEN.activeProject.collaborators[agent.split("/").pop()].roles.includes("LEADER") && leaderCount === 1) {
+            this.shadowRoot.innerHTML = `
+                <h3>User Error</h3>
+                <p>You are the last remaining leader.  You must appoint another leader before you leave.</p>
+            `
+            return
+        }
+        this.shadowRoot.innerHTML = `
+            <style>
+                #leaveBtn {
+                    background-color: var(--primary-color);
+                    padding: 10px 20px;
+                    cursor: pointer;
+                    color: white;
+                    border: none;
+                    font-size: 15pt;
+                    margin-top: 1em;
+                }
+
+                #leaveBtn:hover {
+                    background-color: var(--accent);
+                }
+
+                h2 {
+                    color: var(--accent);
+                }
+
+            </style>
+            <h2>Leave ${TPEN.activeProject.label}</h2>
+            <p>
+                When you leave a project you lose any access to it you have and may no 
+                longer be able to see some content, even content you created. You will no 
+                longer appear as a collaborator and the project will not appear in your projects 
+                list.  To restore access you will have to be invited into the project again.
+            </p>
+            <button id="leaveBtn">I Am Ready To Leave This Project</button>
+        `
+        this.attachEventListeners()
+    }
+
+    attachEventListeners() {
+        const leaveBtn = this.shadowRoot.getElementById("leaveBtn")
+        leaveBtn.addEventListener('click', (ev) => this.leaveProject())
+    }
+
+    leaveProject() {
+        if (!confirm("You are leaving this TPEN3 project.")) return
+        let redir = true
+        const leaveBtn = this.shadowRoot.getElementById("leaveBtn")
+        leaveBtn.setAttribute("disabled", "disabled")
+        leaveBtn.setAttribute("value", "leaving...")
+
+        fetch(`${TPEN.servicesURL}/project/${TPEN.activeProject._id}/leave`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${TPEN.getAuthorization()}`
+            }
+        })
+        .then(resp => {
+            if (resp.ok) return resp.text()
+            redir = false
+            return resp.json()
+        })
+        .then(message => {
+            let userMessage = (typeof message === "string") ? message : message?.message
+            if (redir) {
+                this.shadowRoot.innerHTML = `
+                    <h3>Now you are not a project member.  Goodbye 👋</h3>
+                `
+                setTimeout(() => {
+                  document.location.href = TPEN.BASEURL
+                }, 2500)
+                return
+            }
+            this.shadowRoot.innerHTML = `
+                <h3>There was an error leaving the project.</h3>
+                <p>
+                    The message below has more details.
+                    Refresh the page to try again or contact the TPEN3 Administrators.  
+                </p>
+                <code>${userMessage}<code>
+            `
+        })
+        .catch(err => {
+             this.shadowRoot.innerHTML = `
+                <h3> 
+                    There was an error leaving the project.  Refresh the page to try again 
+                    or contact the TPEN3 Administrators. 
+                </h3>
+            `
+        })
+    }
+}
+
+customElements.define('tpen-project-leave', LeaveProject)

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -34,7 +34,7 @@ class LeaveProject extends HTMLElement {
         if (!agent || !collaboratorIdList.includes(agent.split("/").pop())) {
             this.shadowRoot.innerHTML = `
                 <h3>User Error</h3>
-                <p>The user agent could not be detected or does not have access to this page.</p>
+                <p>Your user agent could not be detected or you are not a member of the project.</p>
             `
             return
         }

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -15,7 +15,7 @@ class LeaveProject extends HTMLElement {
         `
         if (!TPEN.screen.projectInQuery) {
             this.shadowRoot.innerHTML = `
-                <h3>The URL Parameter '?projectID' must be present and have a value in order to use this page.</h3>
+                <h3>The URL Parameter '?projectID' must be present and have a value.</h3>
             `
             return
         }

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -75,7 +75,7 @@ class LeaveProject extends HTMLElement {
             </style>
             <h2>Leave ${TPEN.activeProject.label}</h2>
             <p>
-                When you leave a project you lose any access to it you have and may no 
+                When you leave a project you lose all access to it and may no 
                 longer be able to see some content, even content you created. You will no 
                 longer appear as a collaborator and the project will not appear in your projects 
                 list.  To restore access you will have to be invited into the project again.

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -98,7 +98,7 @@ class LeaveProject extends HTMLElement {
         leaveBtn.setAttribute("value", "leaving...")
 
         fetch(`${TPEN.servicesURL}/project/${TPEN.activeProject._id}/leave`, {
-            method: 'GET',
+            method: 'POST',
             headers: {
                 'Authorization': `Bearer ${TPEN.getAuthorization()}`
             }
@@ -116,7 +116,7 @@ class LeaveProject extends HTMLElement {
                 `
                 setTimeout(() => {
                   document.location.href = TPEN.BASEURL
-                }, 2500)
+                }, 3000)
                 return
             }
             this.shadowRoot.innerHTML = `

--- a/components/leave-project/index.js
+++ b/components/leave-project/index.js
@@ -13,6 +13,12 @@ class LeaveProject extends HTMLElement {
         this.shadowRoot.innerHTML = `
             <h3>Loading...</h3>
         `
+        if (!TPEN.screen.projectInQuery) {
+            this.shadowRoot.innerHTML = `
+                <h3>The URL Parameter '?projectID' must be present and have a value in order to use this page.</h3>
+            `
+            return
+        }
         if (TPEN.activeProject?._id) this.render.bind(this)
         TPEN.eventDispatcher.on('tpen-project-loaded', this.render.bind(this))
         TPEN.eventDispatcher.on('tpen-project-load-failed', (err) => {

--- a/interfaces/manage-project/index.html
+++ b/interfaces/manage-project/index.html
@@ -35,6 +35,7 @@ permalink: /project/manage
                     </tpen-can>
                 </div>
             </div>
+            <button id="leave-project-btn" slot="footer" type="button">LEAVE PROJECT</button>
         </tpen-card>
         <tpen-card tpen-scope="metadata">
             <h2 slot="header">Metadata</h2>

--- a/interfaces/manage-project/index.js
+++ b/interfaces/manage-project/index.js
@@ -47,6 +47,10 @@ document.getElementById('manage-project-options-btn').addEventListener('click', 
     window.location.href = `/project/options?projectID=${TPEN.screen.projectInQuery}`
 })
 
+document.getElementById('leave-project-btn').addEventListener('click', (e) => {
+    window.location.href = `/project/leave?projectID=${TPEN.screen.projectInQuery}`
+})
+
 async function render() {
     const isManageProjectPermission = await CheckPermissions.checkEditAccess('PROJECT')
     if(!isManageProjectPermission) {

--- a/interfaces/project/index.html
+++ b/interfaces/project/index.html
@@ -72,6 +72,7 @@ permalink: /project
                         </tpen-can>
                     </div>
                 </div>
+                <button id="leaveProject" slot="footer" type="button">LEAVE PROJECT</button>
             </tpen-card>
         </div>
     </tpen-page>
@@ -81,6 +82,10 @@ permalink: /project
     TPEN.eventDispatcher.on('tpen-project-loaded', ev => {
         const goParse = document.getElementById("goParse")
         const goTranscribe = document.getElementById("goTranscribe")
+        const leaveProject = document.getElementById("leaveProject")
+        leaveProject.addEventListener('click', (e) => {
+            window.location.href = `/project/leave?projectID=${ev.detail._id}`
+        })
         if(goParse) goParse.setAttribute("href", `/annotator/?projectID=${ev.detail._id}`)
         if(goTranscribe) goTranscribe.setAttribute("href", `/transcribe/?projectID=${ev.detail._id}`)
     })

--- a/interfaces/project/leave.html
+++ b/interfaces/project/leave.html
@@ -1,0 +1,24 @@
+---
+title: Leave Project
+permalink: /project/leave
+---
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Leave Project</title>
+    <script src="../../components/leave-project/index.js" type="module"></script>
+    <script type="module" src="../../components/gui/site/index.js"></script>
+    <link href="../../components/gui/site/index.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+    <tpen-page>
+        <tpen-project-leave></tpen-project-leave>
+    </tpen-page>
+</body>
+
+</html>


### PR DESCRIPTION
This interfaces works with the TPEN3 Services code addition found in https://github.com/CenterForDigitalHumanities/TPEN-services/pull/289.

Added a button on the 'manage project' and 'project detail' page that takes the user into the interface to leave the project.