### PR TITLE
WIP: Canvases That Do Not Resolve

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -391,6 +391,7 @@ TPEN.eventDispatcher.on('tpen-project-loaded', (ev) => {
 // - tpen-project-load-failed: Project load failed
 // - tpen-page-selected: Page selected in page selector ({ pageId, pageIndex, page })
 // - tpen-toast: Show toast message ({ status, message })
+// - tpen-canvas-resolution-failed: Canvas fetch failed ({ errorType, message, httpStatus, canvasUri, component })
 // - token-expiration: Auth token expired
 
 // DOM custom events for component communication

--- a/components/annotorious-annotator/plain.js
+++ b/components/annotorious-annotator/plain.js
@@ -14,6 +14,7 @@
 import TPEN from '../../api/TPEN.js'
 import User from '../../api/User.js'
 import { CleanupRegistry } from '../../utilities/CleanupRegistry.js'
+import vault from '../../js/vault.js'
 
 class AnnotoriousAnnotator extends HTMLElement {
     #osd
@@ -147,17 +148,18 @@ class AnnotoriousAnnotator extends HTMLElement {
     async renderCanvas(resolvedCanvas) {
       this.shadowRoot.getElementById('annotator-container').innerHTML = ""
       const canvasID = resolvedCanvas["@id"] ?? resolvedCanvas.id
-      const fullImage = resolvedCanvas?.items[0]?.items[0]?.body?.id
-      const imageService = resolvedCanvas?.items[0]?.items[0]?.body?.service?.id
-      
+      // Handle both IIIF v3 (items) and v2 (images) formats
+      const fullImage = resolvedCanvas?.items?.[0]?.items?.[0]?.body?.id ?? resolvedCanvas?.images?.[0]?.resource?.id ?? resolvedCanvas?.images?.[0]?.resource?.['@id']
+      const imageService = resolvedCanvas?.items?.[0]?.items?.[0]?.body?.service?.id ?? resolvedCanvas?.images?.[0]?.resource?.service?.['@id']
+
       if(!fullImage) {
-          throw new Error("Cannot Resolve Canvas Image", 
+          throw new Error("Cannot Resolve Canvas Image",
             {"cause":"The Image is 404 or unresolvable."})
       }
 
       this.#imageDims = [
-        resolvedCanvas?.items[0]?.items[0]?.body?.width,
-        resolvedCanvas?.items[0]?.items[0]?.body?.height
+        resolvedCanvas?.items?.[0]?.items?.[0]?.body?.width ?? resolvedCanvas?.images?.[0]?.resource?.width,
+        resolvedCanvas?.items?.[0]?.items?.[0]?.body?.height ?? resolvedCanvas?.images?.[0]?.resource?.height
       ]
       this.#canvasDims = [
         resolvedCanvas?.width,
@@ -325,38 +327,43 @@ class AnnotoriousAnnotator extends HTMLElement {
 
     /**
      * Fetch a Canvas URI and check that it is a Canvas object.  Pass it forward to render the Image into the interface.
-     *
-     * FIXME
-     * Give users a path when Canvas URIs do not resolve or resolve to something unexpected.
+     * Uses vault for consistent caching and error handling.
      *
      * @param uri A String Canvas URI
     */
     async processCanvas(uri) {
-      const canvas = uri
-      if(!canvas) return
-      const resolvedCanvas = await fetch(canvas)
-        .then(r => {
-            if(!r.ok) throw r
-            return r.json()
-        })
-        .catch(e => {
-            throw e
-        })
-      const context = resolvedCanvas["@context"]
-      if(!context.includes("iiif.io/api/presentation/3/context.json")) {
-        console.warn("The Canvas object did not have the IIIF Presentation API 3 context and may not be parseable.")
+      if(!uri) return
+      const resolvedCanvas = await vault.get(uri, 'canvas', false, 'tpen-plain-annotator')
+      if(!resolvedCanvas) {
+        // Canvas resolution failed - event already dispatched by vault
+        this.renderCanvasError(uri)
+        return
       }
-      const id = resolvedCanvas["@id"] ?? resolvedCanvas.id
-      if(!id) {
-          throw new Error("Cannot Resolve Canvas or Image",
-            {"cause":"The Canvas is 404 or unresolvable."})
+      try {
+        await this.renderCanvas(resolvedCanvas)
+      } catch (err) {
+        // Canvas resolved but image extraction failed
+        this.renderCanvasError(uri, err.message)
       }
-      const type = resolvedCanvas["@type"] ?? resolvedCanvas.type
-      if(type !== "Canvas") {
-          throw new Error(`Provided URI did not resolve a 'Canvas'.  It resolved a '${type}'`, 
-            {"cause":"URI must point to a Canvas."})
+    }
+
+    /**
+     * Renders an error message when canvas resolution fails.
+     * @param {string} uri - The canvas URI that failed to resolve
+     * @param {string} [errorMessage] - Optional error message to display
+     */
+    renderCanvasError(uri, errorMessage) {
+      const container = this.shadowRoot.querySelector('#annotoriousContainer') ?? this.shadowRoot
+      if (container) {
+        const message = errorMessage ?? 'The canvas image could not be loaded.'
+        container.innerHTML = `
+          <div style="padding: 2rem; text-align: center; background: #fff3cd; border: 1px solid #ffc107; border-radius: 8px; margin: 1rem;">
+            <h3 style="color: #856404; margin-bottom: 1rem;">Canvas Not Available</h3>
+            <p style="color: #856404; margin-bottom: 0.5rem;">${message}</p>
+            <p style="color: #666; font-size: 0.875rem; word-break: break-all;">${uri}</p>
+          </div>
+        `
       }
-      this.renderCanvas(resolvedCanvas)
     }
 
     /**

--- a/interfaces/manage-project/index.html
+++ b/interfaces/manage-project/index.html
@@ -22,7 +22,7 @@ permalink: /project/manage
             <div slot="body">
                 <tpen-project-details></tpen-project-details>
                 <div class="action-links">
-                    <tpen-can tpen-view="*_SELECTOR_LINE"> 
+                    <tpen-can tpen-view="ANY_SELECTOR_LINE">
                         <a id="goParse" title="Go Parse Lines" class="left"><img src="../../assets/icons/parse-lines.svg" alt="icon"/>
                             <span>Parse Lines</span>
                         </a>

--- a/interfaces/project/index.html
+++ b/interfaces/project/index.html
@@ -69,7 +69,7 @@ permalink: /project
                 <div slot="body">
                     <tpen-project-details class="card"></tpen-project-details>
                     <div class="action-links">
-                        <tpen-can tpen-view="*_SELECTOR_LINE">
+                        <tpen-can tpen-view="ANY_SELECTOR_LINE">
                             <a id="goParse" title="Go Parse Lines" class="left"><img src="../../assets/icons/parse-lines.svg"/>
                                 <span>Parse Lines</span>
                             </a>

--- a/interfaces/transcription/index.js
+++ b/interfaces/transcription/index.js
@@ -49,6 +49,24 @@ export default class TranscriptionInterface extends HTMLElement {
     this.cleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-previous-line', () => this.updateLines())
     this.cleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-next-line', () => this.updateLines())
 
+    // Listen for canvas resolution failures to show toast
+    this.cleanup.onEvent(TPEN.eventDispatcher, 'tpen-canvas-resolution-failed', (event) => {
+      const { errorType } = event.detail ?? {}
+      let userMessage = 'Failed to load canvas image.'
+      if (errorType === 'not_found') {
+        userMessage = 'Canvas not found. The image may have been moved or deleted.'
+      } else if (errorType === 'unauthorized' || errorType === 'forbidden') {
+        userMessage = 'Access denied to canvas image.'
+      } else if (errorType === 'network') {
+        userMessage = 'Network error loading canvas. Check your connection.'
+      } else if (errorType === 'server_error') {
+        userMessage = 'Server error loading canvas. Please try again later.'
+      } else if (errorType === 'invalid_json' || errorType === 'invalid_type' || errorType === 'missing_id') {
+        userMessage = 'The canvas data is invalid or incomplete.'
+      }
+      TPEN.eventDispatcher.dispatch('tpen-toast', { status: 'error', message: userMessage })
+    })
+
     // Listen for navigation messages from tools
     this.cleanup.onWindow('message', this.#handleToolMessages.bind(this))
   }
@@ -611,10 +629,9 @@ export default class TranscriptionInterface extends HTMLElement {
     if (bottomImage) bottomImage.moveUnder(x, y, width, height, topImage)
   }
 
-  getImage(project) {
+  async getImage(project) {
     const imageCanvas = this.shadowRoot.querySelector('.canvas-image')
     let canvasID
-    let err = {}
     const allPages = project.layers.flatMap(layer => layer.pages)
     if (TPEN?.screen?.pageInQuery) {
       const matchingPage = allPages.find(
@@ -625,33 +642,25 @@ export default class TranscriptionInterface extends HTMLElement {
       canvasID = allPages[0]?.target
     }
 
-    fetch(canvasID)
-      .then(response => {
-        if (response.status === 404) {
-          err = { "status": 404, "statusText": "Canvas not found" }
-          throw err
-        }
-        return response.json()
-      })
-      .then(canvas => {
-        // Handle both Presentation API v3 (items) and v2 (images) formats
-        const imageId = canvas.items?.[0]?.items?.[0]?.body?.id ?? canvas.images?.[0]?.resource?.id
-        if (imageId) {
-          imageCanvas.src = imageId
-        }
-        else {
-          err = { "status": 500, "statusText": "Image could not be found in Canvas" }
-          throw err
-        }
-      })
-      .catch(error => {
-        if (error?.status === 404) {
-          imageCanvas.src = "../../assets/images/404_PageNotFound.jpeg"
-        }
-        else {
-          imageCanvas.src = "../../assets/images/noimage.jpg"
-        }
-      })
+    if (!canvasID) {
+      imageCanvas.src = "../../assets/images/noimage.jpg"
+      return
+    }
+
+    const canvas = await vault.get(canvasID, 'canvas', false, 'transcription-interface')
+    if (!canvas) {
+      // Event already dispatched by vault, show placeholder
+      imageCanvas.src = "../../assets/images/404_PageNotFound.jpeg"
+      return
+    }
+
+    // Handle both Presentation API v3 (items) and v2 (images) formats
+    const imageId = canvas.items?.[0]?.items?.[0]?.body?.id ?? canvas.images?.[0]?.resource?.id ?? canvas.images?.[0]?.resource?.['@id']
+    if (imageId) {
+      imageCanvas.src = imageId
+    } else {
+      imageCanvas.src = "../../assets/images/noimage.jpg"
+    }
   }
 
   setCanvasAndSelector(thisLine, page) {
@@ -680,7 +689,13 @@ export default class TranscriptionInterface extends HTMLElement {
       // Get canvas from page target even when there are no lines
       const { canvasID } = this.setCanvasAndSelector(null, this.#page)
       if (!canvasID) return
-      const canvas = this.#canvas = await vault.get(canvasID, 'canvas')
+      const canvas = this.#canvas = await vault.get(canvasID, 'canvas', false, 'transcription-interface')
+      if (!canvas) {
+        // Canvas resolution failed - event already dispatched by vault
+        // Show placeholder for the canvas area
+        topImage.setAttribute('region', '0,0,1000,100')
+        return
+      }
       // Show full page when there are no lines
       const regionValue = `0,0,${canvas?.width ?? 'full'},${(canvas?.height && canvas?.height / 10) ?? 120}`
       topImage.canvas = canvasID
@@ -697,7 +712,14 @@ export default class TranscriptionInterface extends HTMLElement {
     
     if (!(thisLine?.body)) thisLine = await vault.get(thisLine, 'annotation', true)
     const { canvasID, region } = this.setCanvasAndSelector(thisLine, this.#page)
-    const canvas = this.#canvas = await vault.get(canvasID, 'canvas')
+    const canvas = this.#canvas = await vault.get(canvasID, 'canvas', false, 'transcription-interface')
+    if (!canvas) {
+      // Canvas resolution failed - event already dispatched by vault
+      // Use placeholder region dimensions
+      topImage.canvas = canvasID
+      topImage.setAttribute('region', region ?? '0,0,1000,100')
+      return
+    }
     const regionValue = region ?? `0,0,${canvas?.width ?? 'full'},${(canvas?.height && canvas?.height / 10) ?? 120}`
     topImage.canvas = canvasID
     bottomImage.canvas = canvas

--- a/js/vault.js
+++ b/js/vault.js
@@ -1,6 +1,11 @@
 // Local simulacrum vault for use in client without something like webpack
 import TPEN from "../api/TPEN.js"
 import { urlFromIdAndType } from "../js/utils.js"
+
+/**
+ * Vault - Client-side caching utility for IIIF resources.
+ * Provides memory and localStorage caching with type-specific validation.
+ */
 class Vault {
     constructor() {
         this.store = new Map()
@@ -18,21 +23,130 @@ class Vault {
         return `vault:${itemType}:${id}`
     }
 
-    async get(item, itemType, noCache = false) {
+    /**
+     * Creates a standardized canvas error object.
+     * @param {string} errorType - Error type: 'network' | 'server_error' | 'not_found' | 'forbidden' | 'unauthorized' | 'invalid_json' | 'invalid_type' | 'missing_id'
+     * @param {string} message - Human-readable error message
+     * @param {number|null} httpStatus - HTTP status code (if applicable)
+     * @param {string} canvasUri - The canvas URI that failed
+     * @param {string} [component] - Which component triggered the fetch
+     * @returns {Object} Standardized error object
+     */
+    _createCanvasError(errorType, message, httpStatus, canvasUri, component) {
+        return {
+            errorType,
+            message,
+            httpStatus,
+            canvasUri,
+            component
+        }
+    }
+
+    /**
+     * Validates that a fetched object is a valid IIIF Canvas.
+     * Supports both IIIF Presentation API v2 and v3 formats.
+     * @param {Object} canvas - The fetched canvas data
+     * @param {string} uri - The canvas URI (for error reporting)
+     * @returns {Object|null} Error object if invalid, null if valid
+     */
+    _validateCanvas(canvas, uri) {
+        // Check for id (v3: id, v2: @id)
+        const canvasId = canvas?.id ?? canvas?.['@id']
+        if (!canvasId) {
+            return this._createCanvasError('missing_id', 'Canvas has no id field', null, uri)
+        }
+
+        // Check for type (v3: type, v2: @type)
+        const canvasType = canvas?.type ?? canvas?.['@type']
+        if (!canvasType) {
+            return this._createCanvasError('invalid_type', 'Canvas has no type field', null, uri)
+        }
+
+        // Valid Canvas types: 'Canvas' (v3) or 'sc:Canvas' (v2)
+        const validTypes = ['Canvas', 'sc:Canvas']
+        if (!validTypes.includes(canvasType)) {
+            return this._createCanvasError('invalid_type', `Expected Canvas type, got '${canvasType}'`, null, uri)
+        }
+
+        // Check IIIF context - only warn, don't fail
+        const context = canvas?.['@context']
+        if (context) {
+            const validContexts = [
+                'http://iiif.io/api/presentation/2/context.json',
+                'https://iiif.io/api/presentation/2/context.json',
+                'http://iiif.io/api/presentation/3/context.json',
+                'https://iiif.io/api/presentation/3/context.json'
+            ]
+            const contexts = Array.isArray(context) ? context : [context]
+            const hasValidContext = contexts.some(c => validContexts.includes(c))
+            if (!hasValidContext) {
+                console.warn(`Canvas ${uri} has non-standard IIIF context:`, context)
+            }
+        }
+
+        return null // Valid canvas
+    }
+
+    /**
+     * Dispatches a canvas resolution failure event.
+     * @param {Object} error - The error object from _createCanvasError
+     */
+    _dispatchCanvasError(error) {
+        TPEN.eventDispatcher?.dispatch('tpen-canvas-resolution-failed', error)
+    }
+
+    /**
+     * Maps HTTP status codes to error types.
+     * @param {number} status - HTTP status code
+     * @returns {string} Error type
+     */
+    _httpStatusToErrorType(status) {
+        if (status === 404) return 'not_found'
+        if (status === 401) return 'unauthorized'
+        if (status === 403) return 'forbidden'
+        if (status >= 500) return 'server_error'
+        return 'server_error'
+    }
+
+    /**
+     * Fetches and caches a resource by ID and type.
+     * For canvas type, performs validation and dispatches events on failure.
+     * @param {string|Object} item - Item ID or object with id property
+     * @param {string} itemType - Type of item ('canvas', 'manifest', etc.)
+     * @param {boolean} [noCache=false] - Skip cache lookup
+     * @param {string} [component] - Component name for error reporting (which component triggered the fetch)
+     * @returns {Promise<Object|null>} The fetched resource or null on failure
+     */
+    async get(item, itemType, noCache = false, component) {
         const type = this._normalizeType(itemType ?? item?.type ?? item?.['@type'])
         const id = this._getId(item)
+        const isCanvas = type === 'canvas'
         const typeStore = this.store.get(type)
         let result = typeStore?.get(id)
         if (result) return result
 
         const cacheKey = this._cacheKey(type, id)
-        const cached = localStorage.getItem(cacheKey)
+        let cached
+        try { cached = localStorage.getItem(cacheKey) } catch {}
         if (cached && !noCache) {
             try {
                 const parsed = JSON.parse(cached)
+                // Validate cached canvas data
+                if (isCanvas) {
+                    const validationError = this._validateCanvas(parsed, id)
+                    if (validationError) {
+                        validationError.component = component
+                        this._dispatchCanvasError(validationError)
+                        try { localStorage.removeItem(cacheKey) } catch {}
+                        return null
+                    }
+                }
                 this.set(parsed, type)
                 return parsed
-            } catch {}
+            } catch {
+                // Invalid JSON in cache, remove it
+                try { localStorage.removeItem(cacheKey) } catch {}
+            }
         }
 
         try {
@@ -42,9 +156,49 @@ class Vault {
                 layerId: TPEN.screen?.layerInQuery
             })
             const response = await fetch(uri)
-            if (!response.ok) return null
 
-            const data = await response.json()
+            if (!response.ok) {
+                if (isCanvas) {
+                    const errorType = this._httpStatusToErrorType(response.status)
+                    const error = this._createCanvasError(
+                        errorType,
+                        `HTTP ${response.status}: ${response.statusText}`,
+                        response.status,
+                        uri,
+                        component
+                    )
+                    this._dispatchCanvasError(error)
+                }
+                return null
+            }
+
+            let data
+            try {
+                data = await response.json()
+            } catch (jsonError) {
+                if (isCanvas) {
+                    const error = this._createCanvasError(
+                        'invalid_json',
+                        'Response is not valid JSON',
+                        response.status,
+                        uri,
+                        component
+                    )
+                    this._dispatchCanvasError(error)
+                }
+                return null
+            }
+
+            // Validate canvas structure
+            if (isCanvas) {
+                const validationError = this._validateCanvas(data, uri)
+                if (validationError) {
+                    validationError.component = component
+                    this._dispatchCanvasError(validationError)
+                    return null
+                }
+            }
+
             const queue = [{ obj: data, depth: 0 }]
             const visited = new Set()
 
@@ -66,7 +220,8 @@ class Vault {
                     const type = value?.['@type'] ?? value?.type
                     if (id && type && !visited.has(id)) {
                         visited.add(id)
-                        this.get(id, type)
+                        // Fire-and-forget for background caching - errors are non-fatal
+                        this.get(id, type).catch(() => {})
                         // Project embedded object to minimal form
                         const label = value?.label ?? value?.title
                         obj[key] = { id, type, ...(label && { label }) }
@@ -78,8 +233,18 @@ class Vault {
                 localStorage.setItem(cacheKey, JSON.stringify(data))
             } catch {}
             return data
-        } catch {
-            return
+        } catch (err) {
+            if (isCanvas) {
+                const error = this._createCanvasError(
+                    'network',
+                    err.message || 'Network error',
+                    null,
+                    id,
+                    component
+                )
+                this._dispatchCanvasError(error)
+            }
+            return null
         }
     }
 
@@ -104,16 +269,18 @@ class Vault {
         if (!typeStore.has(id)) return
         typeStore.delete(id)
         const cacheKey = this._cacheKey(type, id)
-        localStorage.removeItem(cacheKey)
+        try { localStorage.removeItem(cacheKey) } catch {}
     }
 
     clear(itemType) {
         const type = this._normalizeType(itemType)
-        for (const key of Object.keys(localStorage)) {
-            if (key.startsWith(`vault:${type}:`)) {
-                localStorage.removeItem(key)
+        try {
+            for (const key of Object.keys(localStorage)) {
+                if (key.startsWith(`vault:${type}:`)) {
+                    localStorage.removeItem(key)
+                }
             }
-        }
+        } catch {}
         this.store.delete(type)
     }
 


### PR DESCRIPTION
The goal is to expect Canvas URIs may not resolve, and as part of handling when they don't to look into the Project or Manifest data to see if the Canvas is embedded and can be pulled from there instead.

We are doing this because we know `Canvas` URIs and objects are consistently problematic.  Often the Canvas URI itself does not resolve (because having it embedded in the Manifest was considered good enough and it is kept up to date there).  Since Canvases also contain the Image, they absorb the same issues for the Image.  Often the Image URI is incorrect or won't resolve, or the image is moved, or a paywall in front of the image is implemented, etc.

We want to ensure components and interfaces anticipate this.  Components and interfaces should never hard crash in these scenarios.  Failure to resolve Canvas or Image URIs should always be caught and handled.  Every effort to load the Canvas data should be attempted before throwing a true "could not get canvas" error.

When a component or interface receives a "could not get canvas" or "could not get image" error, it should offer feedback to the user and give them somewhere to go or something to see other than a dead page. 