### PR TITLE
Use vault.getWithFallback for fetching

### DIFF
--- a/components/annotorious-annotator/line-parser.js
+++ b/components/annotorious-annotator/line-parser.js
@@ -563,13 +563,7 @@ class AnnotoriousAnnotator extends HTMLElement {
    */
   async processCanvas(uri) {
     if (!uri) return
-    let resolvedCanvas = await vault.get(uri, 'canvas')
-    if (!resolvedCanvas && TPEN.activeProject?.manifest) {
-      // Canvas not directly resolvable, try to hydrate from all manifests
-      await vault.prefetchManifests(TPEN.activeProject.manifest)
-      // After manifests are cached, try again
-      resolvedCanvas = await vault.get(uri, 'canvas')
-    }
+    let resolvedCanvas = await vault.getWithFallback(uri, 'canvas', TPEN.activeProject?.manifest)
     if (!resolvedCanvas) {
       this.shadowRoot.innerHTML = `
         <h3>Canvas Error</h3>

--- a/components/column-selector/index.js
+++ b/components/column-selector/index.js
@@ -68,11 +68,7 @@ export default class ColumnSelector extends HTMLElement {
             return { ...col, label: isAuto ? `Unnamed ${i + 1}` : col.label }
         })
 
-        this.#page = await vault.get(pageId, 'annotationpage', true)
-        if (!this.#page && TPEN.activeProject?.manifest) {
-            await vault.prefetchManifests(TPEN.activeProject.manifest)
-            this.#page = await vault.get(pageId, 'annotationpage', true)
-        }
+        this.#page = await vault.getWithFallback(pageId, 'annotationpage', TPEN.activeProject?.manifest, true)
         if (!this.#page) return
         const { orderedItems, columnsInPage, allColumnLines } = orderPageItemsByColumns(
             { columns: this.columns, items: page?.items },

--- a/components/continue-working/index.js
+++ b/components/continue-working/index.js
@@ -178,13 +178,7 @@ class ContinueWorking extends HTMLElement {
             if (!canvasId) return this.generateProjectPlaceholder(project)
             
             let canvas, isV3
-            canvas = await vault.get(canvasId, 'canvas')
-            if (!canvas && project.manifest?.[0]) {
-                // Try to hydrate from all manifests
-                await vault.prefetchManifests(project.manifest)
-                // After manifests are cached, try again
-                canvas = await vault.get(canvasId, 'canvas')
-            }
+            canvas = await vault.getWithFallback(canvasId, 'canvas', project.manifest)
             
             if (!canvas) return this.generateProjectPlaceholder(project)
             

--- a/components/default-transcribe/index.js
+++ b/components/default-transcribe/index.js
@@ -71,11 +71,7 @@ class TpenTranscriptionElement extends HTMLElement {
     }
 
     async #loadPage(annotationPageID) {
-        let page = await vault.get(annotationPageID, 'annotationpage')
-        if (!page && TPEN.activeProject?.manifest) {
-            await vault.prefetchManifests(TPEN.activeProject.manifest)
-            page = await vault.get(annotationPageID, 'annotationpage')
-        }
+        let page = await vault.getWithFallback(annotationPageID, 'annotationpage', TPEN.activeProject?.manifest)
         if (!page) {
             return userMessage('Failed to load page. Please try again.')
         }

--- a/components/legacy-annotator/plain.js
+++ b/components/legacy-annotator/plain.js
@@ -314,11 +314,7 @@ class LegacyAnnotator extends HTMLElement {
 
     async processAnnotationPage(page) {
         if(!page) return
-        let resolvedPage = await vault.get(page, 'annotationpage')
-        if (!resolvedPage && TPEN.activeProject?.manifest) {
-            await vault.prefetchManifests(TPEN.activeProject.manifest)
-            resolvedPage = await vault.get(page, 'annotationpage')
-        }
+        let resolvedPage = await vault.getWithFallback(page, 'annotationpage', TPEN.activeProject?.manifest)
         if (!resolvedPage) {
             throw new Error("Cannot Resolve AnnotationPage", {cause: "The AnnotationPage is 404 or unresolvable."})
         }
@@ -399,13 +395,7 @@ class LegacyAnnotator extends HTMLElement {
         const ctx = imageCanvas.getContext("2d")
         let err
         if(!canvas) return
-        let resolvedCanvas = await vault.get(canvas, 'canvas')
-        if (!resolvedCanvas && TPEN.activeProject?.manifest) {
-            // Try to hydrate from all manifests
-            await vault.prefetchManifests(TPEN.activeProject.manifest)
-            // After manifests are cached, try again
-            resolvedCanvas = await vault.get(canvas, 'canvas')
-        }
+        let resolvedCanvas = await vault.getWithFallback(canvas, 'canvas', TPEN.activeProject?.manifest)
         if (!resolvedCanvas) {
             throw new Error("Canvas Error", {cause: "The Canvas could not be resolved"})
         }

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -481,11 +481,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       }
 
       // Use vault.get to fetch the page properly
-      let fetchedPage = await vault.get(pageID, 'annotationpage', true)
-      if (!fetchedPage && TPEN.activeProject?.manifest) {
-        await vault.prefetchManifests(TPEN.activeProject.manifest)
-        fetchedPage = await vault.get(pageID, 'annotationpage', true)
-      }
+      let fetchedPage = await vault.getWithFallback(pageID, 'annotationpage', TPEN.activeProject?.manifest, true)
       if (!fetchedPage) {
         TPEN.eventDispatcher.dispatch("tpen-toast", {
           message: "Failed to load page. Please try again.",
@@ -519,11 +515,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
         canvasID = target.source
       }
 
-      let fetchedCanvas = await vault.get(canvasID, 'canvas')
-      if (!fetchedCanvas && TPEN.activeProject?.manifest) {
-        await vault.prefetchManifests(TPEN.activeProject.manifest)
-        fetchedCanvas = await vault.get(canvasID, 'canvas')
-      }
+      let fetchedCanvas = await vault.getWithFallback(canvasID, 'canvas', TPEN.activeProject?.manifest)
       if (!fetchedCanvas) {
         TPEN.eventDispatcher.dispatch("tpen-toast", {
           message: "Could not load canvas. Please try again.",

--- a/components/transcription-block/index.js
+++ b/components/transcription-block/index.js
@@ -92,14 +92,7 @@ export default class TranscriptionBlock extends HTMLElement {
      */
     async initializeAsync() {
         const pageID = TPEN.screen?.pageInQuery
-        this.#page = await vault.get(pageID, 'annotationpage', true)
-        if (!this.#page && TPEN.activeProject?.manifest) {
-          // Try to hydrate from all manifests
-          const manifestUrls = TPEN.activeProject?.manifest
-          await vault.prefetchManifests(manifestUrls)
-          // After manifests are cached, try again
-          this.#page = await vault.get(pageID, 'annotationpage', true)
-        }
+        this.#page = await vault.getWithFallback(pageID, 'annotationpage', TPEN.activeProject?.manifest, true)
         const projectPage = TPEN.activeProject.layers.flatMap(layer => layer.pages || []).find(p => p.id.split('/').pop() === pageID.split('/').pop())
         if (!this.#page || !projectPage) return
 

--- a/interfaces/transcription/index.js
+++ b/interfaces/transcription/index.js
@@ -624,13 +624,7 @@ export default class TranscriptionInterface extends HTMLElement {
       canvasID = allPages[0]?.target
     }
 
-    let canvas = await vault.get(canvasID, 'canvas')
-    if (!canvas && TPEN.activeProject?.manifest) {
-      // Canvas not directly resolvable, try to hydrate from all manifests
-      await vault.prefetchManifests(TPEN.activeProject.manifest)
-      // After manifests are cached, try again
-      canvas = await vault.get(canvasID, 'canvas')
-    }
+    let canvas = await vault.getWithFallback(canvasID, 'canvas', TPEN.activeProject?.manifest)
     if (!canvas) {
       imageCanvas.src = "../../assets/images/404_PageNotFound.jpeg"
       return
@@ -658,14 +652,7 @@ export default class TranscriptionInterface extends HTMLElement {
     const topImage = this.shadowRoot.querySelector('#topImage')
     const bottomImage = this.shadowRoot.querySelector('#bottomImage')
     topImage.manifest = bottomImage.manifest = TPEN.activeProject?.manifest?.[0]
-    this.#page = await vault.get(pageID, 'annotationpage', true)
-    if (!this.#page && TPEN.activeProject?.manifest) {
-      // Try to hydrate from all manifests
-      const manifestUrls = TPEN.activeProject?.manifest
-      await vault.prefetchManifests(manifestUrls)
-      // After manifests are cached, try again
-      this.#page = await vault.get(pageID, 'annotationpage', true)
-    }
+    this.#page = await vault.getWithFallback(pageID, 'annotationpage', TPEN.activeProject?.manifest, true)
     const projectPage = TPEN.activeProject.layers.flatMap(layer => layer.pages || []).find(p => p.id.split('/').pop() === pageID.split('/').pop())
     if (!this.#page || !projectPage) return
     const { orderedItems, columnsInPage } = orderPageItemsByColumns(projectPage, this.#page)


### PR DESCRIPTION
Replace repeated vault.get + prefetchManifests patterns with a single vault.getWithFallback utility to simplify resource resolution and avoid duplicated manifest-hydration logic. Affected components: annotorious-annotator/line-parser.js, column-selector/index.js, continue-working/index.js, default-transcribe/index.js, legacy-annotator/plain.js, simple-transcription/index.js, transcription-block/index.js, interfaces/transcription/index.js. Preserves existing behavior (including the optional strict flag) while centralizing the fallback to project manifests.