### PR TITLE
Try higher-resolution IIIF images in viewer

### DIFF
--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -756,7 +756,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     const overlayHeight = scaledH * zoom
 
     this.highlightActiveLine(imgTop, overlayLeft, overlayTop, overlayWidth, overlayHeight)
-    this.#maybeUpgradeImageResolution(overlayWidth * zoom)
+    this.#maybeUpgradeImageResolution(overlayWidth)
   }
 
   /**

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -8,6 +8,7 @@ import { renderPermissionError } from "../../utilities/renderPermissionError.js"
 import { orderPageItemsByColumns } from "../../utilities/columnOrdering.js"
 import { onProjectReady } from "../../utilities/projectReady.js"
 import { CleanupRegistry } from '../../utilities/CleanupRegistry.js'
+import { getHigherResolutionImageCandidates } from '../../utilities/imageUpgradeUrl.js'
 
 /**
  * SimpleTranscriptionInterface - The simplified transcription interface with split-pane image viewer.
@@ -19,6 +20,10 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   #canvas
   #activeLine = null
   #activeToolIframe = null
+  #imageService = null
+  #currentImageSrc = null
+  #attemptedUpgradeSources = new Set()
+  #isAttemptingImageUpgrade = false
   #imgTopOriginalHeight = 0
   #imgTopOriginalWidth = 0
   #imgBottomPositionRatio = 1
@@ -523,7 +528,12 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
       // Get the image resource from the canvas
       // Handle both Presentation API v3 (items) and v2 (images) formats
-      const imageResource = fetchedCanvas.items?.[0]?.items?.[0]?.body?.id ?? fetchedCanvas.images?.[0]?.resource?.["@id"] ?? fetchedCanvas.images?.[0]?.resource?.id
+      const paintingBody = fetchedCanvas.items?.[0]?.items?.[0]?.body
+      const imageResource = paintingBody?.id ?? fetchedCanvas.images?.[0]?.resource?.["@id"] ?? fetchedCanvas.images?.[0]?.resource?.id
+      this.#imageService = paintingBody?.service?.[0] ?? paintingBody?.service ?? fetchedCanvas.images?.[0]?.resource?.service?.[0] ?? fetchedCanvas.images?.[0]?.resource?.service ?? null
+      this.#currentImageSrc = imageResource ?? null
+      this.#attemptedUpgradeSources = new Set()
+      this.#isAttemptingImageUpgrade = false
 
       if (!imageResource) {
         TPEN.eventDispatcher.dispatch("tpen-toast", {
@@ -746,6 +756,93 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     const overlayHeight = scaledH * zoom
 
     this.highlightActiveLine(imgTop, overlayLeft, overlayTop, overlayWidth, overlayHeight)
+    this.#maybeUpgradeImageResolution(overlayWidth * zoom)
+  }
+
+  /**
+   * Preload an image candidate and return its natural dimensions.
+   * Expected misses resolve to null so upgrade probing stays quiet.
+   * @param {string} src
+   * @returns {Promise<{src: string, naturalWidth: number, naturalHeight: number} | null>}
+   */
+  #preloadImageSource(src) {
+    return new Promise(resolve => {
+      const testImg = new Image()
+      testImg.onload = () => {
+        resolve({
+          src,
+          naturalWidth: testImg.naturalWidth,
+          naturalHeight: testImg.naturalHeight
+        })
+      }
+      testImg.onerror = () => resolve(null)
+      testImg.src = src
+    })
+  }
+
+  /**
+   * Swap both panes to a new source and refresh line positioning once loaded.
+   * @param {string} src
+   */
+  #swapImageSource(src) {
+    const imgTop = this.shadowRoot.querySelector('#imgTop img')
+    const imgBottom = this.shadowRoot.querySelector('#imgBottom img')
+    if (!imgTop || !imgBottom) return
+
+    this.cleanup.onElement(imgTop, 'load', () => this.updateLines(), { once: true })
+    imgTop.src = src
+    imgBottom.src = src
+    this.#currentImageSrc = src
+  }
+
+  /**
+   * Attempt a higher-resolution image when overlay display width exceeds source width.
+   * @param {number} viewportWidth
+   */
+  async #maybeUpgradeImageResolution(viewportWidth) {
+    if (this.#isAttemptingImageUpgrade || !Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+      return
+    }
+
+    const imgBottom = this.shadowRoot.querySelector('#imgBottom img')
+    if (!imgBottom || !imgBottom.naturalWidth) return
+
+    const currentNaturalWidth = imgBottom.naturalWidth
+    if (currentNaturalWidth >= viewportWidth) return
+
+    const requestedWidth = Math.max(
+      Math.ceil(viewportWidth * 1.25),
+      Math.ceil(currentNaturalWidth * 1.5),
+      Math.ceil(this.#imgTopOriginalWidth || 0)
+    )
+
+    const candidates = getHigherResolutionImageCandidates({
+      imageUrl: this.#currentImageSrc,
+      imageService: this.#imageService,
+      requestedWidth
+    })
+
+    if (candidates.length === 0) return
+
+    this.#isAttemptingImageUpgrade = true
+    try {
+      for (const candidate of candidates) {
+        if (!candidate || candidate === this.#currentImageSrc || this.#attemptedUpgradeSources.has(candidate)) {
+          continue
+        }
+        this.#attemptedUpgradeSources.add(candidate)
+
+        const loaded = await this.#preloadImageSource(candidate)
+        if (!loaded || loaded.naturalWidth <= currentNaturalWidth) {
+          continue
+        }
+
+        this.#swapImageSource(candidate)
+        return
+      }
+    } finally {
+      this.#isAttemptingImageUpgrade = false
+    }
   }
 
   highlightActiveLine(container, leftPx, topPx, widthPx, heightPx) {

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -24,6 +24,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   #currentImageSrc = null
   #attemptedUpgradeSources = new Set()
   #isAttemptingImageUpgrade = false
+  #loadEpoch = 0
   #imgTopOriginalHeight = 0
   #imgTopOriginalWidth = 0
   #imgBottomPositionRatio = 1
@@ -475,6 +476,9 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
   async updateTranscriptionImages(pageID) {
     try {
+      // Invalidate in-flight upgrade attempts from a previous page/canvas.
+      this.#loadEpoch += 1
+
       if (!pageID && TPEN.screen?.pageInQuery) {
         pageID = TPEN.screen.pageInQuery
       }
@@ -756,7 +760,10 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     const overlayHeight = scaledH * zoom
 
     this.highlightActiveLine(imgTop, overlayLeft, overlayTop, overlayWidth, overlayHeight)
-    this.#maybeUpgradeImageResolution(overlayWidth)
+    this.#maybeUpgradeImageResolution({
+      lineWidthIIIF: w,
+      lineWidthScreen: overlayWidth
+    })
   }
 
   /**
@@ -796,22 +803,35 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   }
 
   /**
-   * Attempt a higher-resolution image when overlay display width exceeds source width.
-   * @param {number} viewportWidth
+   * Attempt a higher-resolution image when the active line is under-resolved on screen.
+   * @param {{lineWidthIIIF: number, lineWidthScreen: number}} dimensions
    */
-  async #maybeUpgradeImageResolution(viewportWidth) {
-    if (this.#isAttemptingImageUpgrade || !Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+  async #maybeUpgradeImageResolution(dimensions) {
+    const lineWidthIIIF = dimensions?.lineWidthIIIF
+    const lineWidthScreen = dimensions?.lineWidthScreen
+    if (
+      this.#isAttemptingImageUpgrade
+      || !Number.isFinite(lineWidthIIIF)
+      || lineWidthIIIF <= 0
+      || !Number.isFinite(lineWidthScreen)
+      || lineWidthScreen <= 0
+    ) {
       return
     }
 
     const imgBottom = this.shadowRoot.querySelector('#imgBottom img')
-    if (!imgBottom || !imgBottom.naturalWidth) return
+    if (!imgBottom || !imgBottom.naturalWidth || !this.#imgTopOriginalWidth) return
 
+    const devicePixelRatio = globalThis.devicePixelRatio || 1
     const currentNaturalWidth = imgBottom.naturalWidth
-    if (currentNaturalWidth >= viewportWidth) return
+    const linePixelsAvailable = lineWidthIIIF * (currentNaturalWidth / this.#imgTopOriginalWidth)
+    const linePixelsNeeded = lineWidthScreen * devicePixelRatio
+    if (linePixelsAvailable >= linePixelsNeeded) return
+
+    const naturalWidthNeeded = (linePixelsNeeded * this.#imgTopOriginalWidth) / lineWidthIIIF
 
     const requestedWidth = Math.max(
-      Math.ceil(viewportWidth * 1.25),
+      Math.ceil(naturalWidthNeeded * 1.1),
       Math.ceil(currentNaturalWidth * 1.5),
       Math.ceil(this.#imgTopOriginalWidth || 0)
     )
@@ -824,16 +844,25 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
     if (candidates.length === 0) return
 
+    const epoch = this.#loadEpoch
     this.#isAttemptingImageUpgrade = true
     try {
       for (const candidate of candidates) {
+        if (epoch !== this.#loadEpoch) return
+
         if (!candidate || candidate === this.#currentImageSrc || this.#attemptedUpgradeSources.has(candidate)) {
           continue
         }
         this.#attemptedUpgradeSources.add(candidate)
 
         const loaded = await this.#preloadImageSource(candidate)
+        if (epoch !== this.#loadEpoch) return
         if (!loaded || loaded.naturalWidth <= currentNaturalWidth) {
+          continue
+        }
+
+        const upgradedLinePixelsAvailable = lineWidthIIIF * (loaded.naturalWidth / this.#imgTopOriginalWidth)
+        if (upgradedLinePixelsAvailable < linePixelsNeeded) {
           continue
         }
 

--- a/utilities/imageUpgradeUrl.js
+++ b/utilities/imageUpgradeUrl.js
@@ -1,0 +1,168 @@
+/**
+ * Normalize a IIIF Image service block to a base service URL.
+ * @param {object|string|null|undefined} service
+ * @returns {string|null}
+ */
+function getIIIFServiceBase(service) {
+  if (!service) return null
+
+  if (typeof service === 'string') {
+    return service.replace(/\/$/, '')
+  }
+
+  const id = service.id ?? service['@id']
+  if (!id || typeof id !== 'string') return null
+
+  return id.replace(/\/$/, '')
+}
+
+/**
+ * Infer the IIIF Image API major version from a service block.
+ * @param {object|string|null|undefined} service
+ * @returns {2|3|null}
+ */
+function getIIIFImageApiMajorVersion(service) {
+  if (!service || typeof service === 'string') return null
+
+  const type = service.type ?? ''
+  if (typeof type === 'string') {
+    if (type.includes('ImageService3')) return 3
+    if (type.includes('ImageService2')) return 2
+  }
+
+  const context = service['@context'] ?? service.context
+  const contexts = Array.isArray(context) ? context : [context]
+  for (const entry of contexts) {
+    if (typeof entry !== 'string') continue
+    if (entry.includes('/image/3/context.json')) return 3
+    if (entry.includes('/image/2/context.json')) return 2
+  }
+
+  const profile = service.profile
+  const profiles = Array.isArray(profile) ? profile : [profile]
+  for (const entry of profiles) {
+    if (typeof entry !== 'string') continue
+    if (entry.includes('/image/3/')) return 3
+    if (entry.includes('/image/2/')) return 2
+  }
+
+  return null
+}
+
+/**
+ * Build URL candidates using an IIIF Image service.
+ * @param {string|null} imageUrl
+ * @param {object|string|null|undefined} service
+ * @param {number} requestedWidth
+ * @returns {string[]}
+ */
+function buildServiceCandidates(imageUrl, service, requestedWidth) {
+  const serviceBase = getIIIFServiceBase(service)
+  if (!serviceBase) return []
+
+  const version = getIIIFImageApiMajorVersion(service)
+  const fullSizeToken = version === 2 ? 'full' : 'max'
+  const width = requestedWidth > 2000 ? fullSizeToken : Math.max(1, Math.floor(requestedWidth))
+  const sizeSegment = typeof width === 'number' ? `${width},` : width
+  const candidates = [
+    `${serviceBase}/full/${sizeSegment}/0/default.jpg`,
+    `${serviceBase}/full/${sizeSegment}/0/default.png`,
+    `${serviceBase}/full/${sizeSegment}/0/native.jpg`
+  ]
+
+  // Some manifests point imageUrl directly to a service endpoint.
+  if (imageUrl && imageUrl !== serviceBase) {
+    candidates.unshift(imageUrl)
+  }
+
+  return candidates
+}
+
+/**
+ * Build URL candidates by rewriting known IIIF path segments.
+ * @param {string|null} imageUrl
+ * @param {number} requestedWidth
+ * @returns {string[]}
+ */
+function buildPathCandidates(imageUrl, requestedWidth) {
+  if (!imageUrl) return []
+
+  const width = Math.max(1, Math.floor(requestedWidth))
+  const candidates = []
+  const iiifPathRegex = /(\/full\/)([^/]+)(\/[^/]+\/[^/?#]+)/
+
+  if (iiifPathRegex.test(imageUrl)) {
+    candidates.push(imageUrl.replace(iiifPathRegex, `$1${width},$3`))
+  }
+
+  return candidates
+}
+
+/**
+ * Build URL candidates by increasing common width/zoom query params.
+ * @param {string|null} imageUrl
+ * @param {number} requestedWidth
+ * @returns {string[]}
+ */
+function buildQueryCandidates(imageUrl, requestedWidth) {
+  if (!imageUrl) return []
+
+  let parsed
+  try {
+    parsed = new URL(imageUrl, globalThis.location?.href)
+  } catch {
+    return []
+  }
+
+  const width = Math.max(1, Math.floor(requestedWidth))
+  const widthParams = ['w', 'width', 'size']
+  const zoomParams = ['zoom', 'scale', 'resolution']
+  const out = []
+
+  for (const key of widthParams) {
+    if (!parsed.searchParams.has(key)) continue
+    const next = new URL(parsed.toString())
+    next.searchParams.set(key, String(width))
+    out.push(next.toString())
+  }
+
+  for (const key of zoomParams) {
+    if (!parsed.searchParams.has(key)) continue
+    const current = Number(parsed.searchParams.get(key))
+    if (!Number.isFinite(current)) continue
+    const next = new URL(parsed.toString())
+    next.searchParams.set(key, String(Math.max(current * 1.5, 2)))
+    out.push(next.toString())
+  }
+
+  return out
+}
+
+/**
+ * Return unique higher-resolution URL candidates in priority order.
+ * @param {{
+ *   imageUrl: string | null,
+ *   imageService?: object | string | null,
+ *   requestedWidth: number
+ * }} options
+ * @returns {string[]}
+ */
+export function getHigherResolutionImageCandidates(options) {
+  const { imageUrl, imageService = null, requestedWidth } = options
+  const candidates = [
+    ...buildServiceCandidates(imageUrl, imageService, requestedWidth),
+    ...buildPathCandidates(imageUrl, requestedWidth),
+    ...buildQueryCandidates(imageUrl, requestedWidth)
+  ]
+
+  const seen = new Set()
+  const deduped = []
+
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) continue
+    seen.add(candidate)
+    deduped.push(candidate)
+  }
+
+  return deduped
+}


### PR DESCRIPTION
Add automatic image upgrade probing to the SimpleTranscription viewer. Introduces utilities/imageUpgradeUrl.js to build prioritized, deduplicated higher-resolution URL candidates (IIIF service, path rewrites, and query param adjustments). Update components/simple-transcription to track image service and current source, preload candidates, check natural dimensions, and swap both panes to a better source when the viewport demands higher resolution. Includes safeguards to avoid repeated attempts, to silence misses, and to only swap after verifying increased natural width.