### PR TITLE
Hotfix splitscreen messages

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -22,7 +22,7 @@ export const ACTIVE_ENV = (
 
 export const ENVIRONMENTS = {
   dev: {
-    BASEURL: 'http://localhost:4000',
+    BASEURL: 'https://dev.app.t-pen.org',
     servicesURL: 'https://dev.api.t-pen.org',
     tinyThingsURL: 'https://dev.tiny.t-pen.org',
     staticURL: 'https://dev.static.t-pen.org',
@@ -31,11 +31,11 @@ export const ENVIRONMENTS = {
     TPEN3URL: 'https://three.t-pen.org',
   },
   prod: {
-    BASEURL: 'http://localhost:4000',
-    servicesURL: 'https://dev.api.t-pen.org',
-    tinyThingsURL: 'https://dev.tiny.t-pen.org',
-    staticURL: 'https://dev.static.t-pen.org',
-    RERUMURL: 'https://devstore.rerum.io/v1',
+    BASEURL: 'https://app.t-pen.org',
+    servicesURL: 'https://api.t-pen.org',
+    tinyThingsURL: 'https://tiny.t-pen.org',
+    staticURL: 'https://static.t-pen.org',
+    RERUMURL: 'https://store.rerum.io/v1',
     TPEN28URL: 'https://t-pen.org',
     TPEN3URL: 'https://three.t-pen.org',
   }

--- a/api/config.js
+++ b/api/config.js
@@ -22,7 +22,7 @@ export const ACTIVE_ENV = (
 
 export const ENVIRONMENTS = {
   dev: {
-    BASEURL: 'https://dev.app.t-pen.org',
+    BASEURL: 'http://localhost:4000',
     servicesURL: 'https://dev.api.t-pen.org',
     tinyThingsURL: 'https://dev.tiny.t-pen.org',
     staticURL: 'https://dev.static.t-pen.org',
@@ -31,11 +31,11 @@ export const ENVIRONMENTS = {
     TPEN3URL: 'https://three.t-pen.org',
   },
   prod: {
-    BASEURL: 'https://app.t-pen.org',
-    servicesURL: 'https://api.t-pen.org',
-    tinyThingsURL: 'https://tiny.t-pen.org',
-    staticURL: 'https://static.t-pen.org',
-    RERUMURL: 'https://store.rerum.io/v1',
+    BASEURL: 'http://localhost:4000',
+    servicesURL: 'https://dev.api.t-pen.org',
+    tinyThingsURL: 'https://dev.tiny.t-pen.org',
+    staticURL: 'https://dev.static.t-pen.org',
+    RERUMURL: 'https://devstore.rerum.io/v1',
     TPEN28URL: 'https://t-pen.org',
     TPEN3URL: 'https://three.t-pen.org',
   }

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -923,6 +923,18 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   }
 
   /**
+   * Build the `canvases` payload consumed by the legacy `CANVASES` message
+   * (Compare-Pages, etc.). Mirrors `interfaces/transcription/index.js#fetchCanvasesFromCurrentLayer`
+   * so legacy tools keep receiving the same shape they used to.
+   */
+  #fetchCanvasesFromCurrentLayer() {
+    const currentLayer = TPEN.activeProject?.layers?.find(
+      layer => layer.pages?.some(page => page.id?.split('/').pop() === TPEN.screen?.pageInQuery)
+    )
+    return currentLayer?.pages?.flatMap(page => ({ id: page.target, label: page.label })) ?? []
+  }
+
+  /**
    * Resolve each item in `page.items` to a full Annotation via the vault.
    * Vault fetches for AnnotationPages return children as bare `{id, type}`
    * refs — downstream tools need hydrated targets/selectors/bodies. Returns
@@ -1050,11 +1062,47 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
       iframe.addEventListener('load', () => {
         this.#sendTPENContextToTool(iframe.contentWindow)
+        // Legacy protocol — keeps pre-TPEN_CONTEXT tools working alongside
+        // TPEN_CONTEXT consumers. Mirrors the payloads sent by
+        // `interfaces/transcription/index.js` on iframe load. Each tool
+        // ignores types it doesn't speak.
+        // - MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION: Page-Viewer, Preview-Transcription
+        // - CANVASES: Compare-Pages
+        // - CURRENT_LINE_INDEX: Line-Breaking
+        iframe.contentWindow?.postMessage(
+          {
+            type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',
+            manifest: TPEN.activeProject?.manifest?.[0] ?? '',
+            canvas: this.#canvas?.id ?? this.#canvas?.['@id'] ?? '',
+            annotationPage: this.#page?.id ?? '',
+            annotation: TPEN.activeLineIndex >= 0
+              ? this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
+              : null,
+            columns: TPEN.activeProject?.layers
+              ?.flatMap(layer => layer.pages || [])
+              .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
+          },
+          this._iframeOrigin
+        )
+        iframe.contentWindow?.postMessage(
+          { type: 'CANVASES', canvases: this.#fetchCanvasesFromCurrentLayer() },
+          this._iframeOrigin
+        )
+        iframe.contentWindow?.postMessage(
+          { type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() },
+          this._iframeOrigin
+        )
       })
 
       const sendLineSelection = () => {
+        const currentLineId = this.#getCurrentLineId()
         iframe.contentWindow?.postMessage(
-          { type: 'UPDATE_CURRENT_LINE', currentLineId: this.#getCurrentLineId() },
+          { type: 'UPDATE_CURRENT_LINE', currentLineId },
+          this._iframeOrigin
+        )
+        // Legacy line-nav update for Line-Breaking and similar tools.
+        iframe.contentWindow?.postMessage(
+          { type: 'CURRENT_LINE_INDEX', lineId: currentLineId },
           this._iframeOrigin
         )
       }

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -954,10 +954,6 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     targetWindow.postMessage(message, this._iframeOrigin)
   }
 
-  async #sendTPENContextToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
-    this.#postToTool(await this.#buildTPENContext(), targetWindow)
-  }
-
   #sendIdTokenToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
     const idToken = TPEN.getAuthorization()
 
@@ -1050,11 +1046,8 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
       iframe.addEventListener('load', () => {
         const target = iframe.contentWindow
-        this.#sendTPENContextToTool(target)
-        // - TPEN_CONTEXT: TPEN Prompts
-        // - MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION: Page-Viewer, Preview-Transcription
-        // - CANVASES: Compare-Pages
-        // - CURRENT_LINE_INDEX: Line-Breaking
+        this.#postToTool(await this.#buildTPENContext(), targetWindow)
+
         this.#postToTool({
           type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',
           manifest: TPEN.activeProject?.manifest?.[0] ?? '',
@@ -1067,25 +1060,25 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
             ?.flatMap(layer => layer.pages || [])
             .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
         }, target)
+
         this.#postToTool({
           type: 'CANVASES',
           canvases: TPEN.activeProject?.layers
             ?.find(layer => layer.pages?.some(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery))
             ?.pages?.flatMap(p => ({ id: p.target, label: p.label })) ?? []
         }, target)
+
         this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() }, target)
       })
 
       const sendLineSelection = () => {
         const currentLineId = this.#getCurrentLineId()
         this.#postToTool({ type: 'UPDATE_CURRENT_LINE', currentLineId })
-        // Legacy line-nav update for Line-Breaking and similar tools.
+
         this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: currentLineId })
       }
-
       this.#toolCleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-previous-line', sendLineSelection)
       this.#toolCleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-next-line', sendLineSelection)
-
       iframe.src = tool.url
       rightPane.innerHTML = ''
       rightPane.appendChild(iframe)

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -1061,50 +1061,33 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       this._iframeOrigin = new URL(tool.url).origin
 
       iframe.addEventListener('load', () => {
-        this.#sendTPENContextToTool(iframe.contentWindow)
-        // Legacy protocol — keeps pre-TPEN_CONTEXT tools working alongside
-        // TPEN_CONTEXT consumers. Mirrors the payloads sent by
-        // `interfaces/transcription/index.js` on iframe load. Each tool
-        // ignores types it doesn't speak.
+        const target = iframe.contentWindow
+        this.#sendTPENContextToTool(target)
+        // - TPEN_CONTEXT: TPEN Prompts
         // - MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION: Page-Viewer, Preview-Transcription
         // - CANVASES: Compare-Pages
         // - CURRENT_LINE_INDEX: Line-Breaking
-        iframe.contentWindow?.postMessage(
-          {
-            type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',
-            manifest: TPEN.activeProject?.manifest?.[0] ?? '',
-            canvas: this.#canvas?.id ?? this.#canvas?.['@id'] ?? '',
-            annotationPage: this.#page?.id ?? '',
-            annotation: TPEN.activeLineIndex >= 0
-              ? this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
-              : null,
-            columns: TPEN.activeProject?.layers
-              ?.flatMap(layer => layer.pages || [])
-              .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
-          },
-          this._iframeOrigin
-        )
-        iframe.contentWindow?.postMessage(
-          { type: 'CANVASES', canvases: this.#fetchCanvasesFromCurrentLayer() },
-          this._iframeOrigin
-        )
-        iframe.contentWindow?.postMessage(
-          { type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() },
-          this._iframeOrigin
-        )
+        this.#postToTool({
+          type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',
+          manifest: TPEN.activeProject?.manifest?.[0] ?? '',
+          canvas: this.#canvas?.id ?? this.#canvas?.['@id'] ?? '',
+          annotationPage: this.#page?.id ?? '',
+          annotation: TPEN.activeLineIndex >= 0
+            ? this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
+            : null,
+          columns: TPEN.activeProject?.layers
+            ?.flatMap(layer => layer.pages || [])
+            .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
+        }, target)
+        this.#postToTool({ type: 'CANVASES', canvases: this.#fetchCanvasesFromCurrentLayer() }, target)
+        this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() }, target)
       })
 
       const sendLineSelection = () => {
         const currentLineId = this.#getCurrentLineId()
-        iframe.contentWindow?.postMessage(
-          { type: 'UPDATE_CURRENT_LINE', currentLineId },
-          this._iframeOrigin
-        )
+        this.#postToTool({ type: 'UPDATE_CURRENT_LINE', currentLineId })
         // Legacy line-nav update for Line-Breaking and similar tools.
-        iframe.contentWindow?.postMessage(
-          { type: 'CURRENT_LINE_INDEX', lineId: currentLineId },
-          this._iframeOrigin
-        )
+        this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: currentLineId })
       }
 
       this.#toolCleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-previous-line', sendLineSelection)

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -922,7 +922,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     return this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
   }
 
-/**
+  /**
    * Resolve each item in `page.items` to a full Annotation via the vault.
    * Vault fetches for AnnotationPages return children as bare `{id, type}`
    * refs — downstream tools need hydrated targets/selectors/bodies. Returns
@@ -952,6 +952,10 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   #postToTool(message, targetWindow = this.#activeToolIframe?.contentWindow) {
     if (!this._iframeOrigin || !targetWindow) return
     targetWindow.postMessage(message, this._iframeOrigin)
+  }
+
+  async #sendTPENContextToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
+    this.#postToTool(await this.#buildTPENContext(), targetWindow)
   }
 
   #sendIdTokenToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
@@ -1046,7 +1050,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
       iframe.addEventListener('load', () => {
         const target = iframe.contentWindow
-        this.#postToTool(await this.#buildTPENContext(), targetWindow)
+        this.#sendTPENContextToTool(target)
 
         this.#postToTool({
           type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -922,19 +922,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     return this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
   }
 
-  /**
-   * Build the `canvases` payload consumed by the legacy `CANVASES` message
-   * (Compare-Pages, etc.). Mirrors `interfaces/transcription/index.js#fetchCanvasesFromCurrentLayer`
-   * so legacy tools keep receiving the same shape they used to.
-   */
-  #fetchCanvasesFromCurrentLayer() {
-    const currentLayer = TPEN.activeProject?.layers?.find(
-      layer => layer.pages?.some(page => page.id?.split('/').pop() === TPEN.screen?.pageInQuery)
-    )
-    return currentLayer?.pages?.flatMap(page => ({ id: page.target, label: page.label })) ?? []
-  }
-
-  /**
+/**
    * Resolve each item in `page.items` to a full Annotation via the vault.
    * Vault fetches for AnnotationPages return children as bare `{id, type}`
    * refs — downstream tools need hydrated targets/selectors/bodies. Returns
@@ -1079,7 +1067,12 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
             ?.flatMap(layer => layer.pages || [])
             .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
         }, target)
-        this.#postToTool({ type: 'CANVASES', canvases: this.#fetchCanvasesFromCurrentLayer() }, target)
+        this.#postToTool({
+          type: 'CANVASES',
+          canvases: TPEN.activeProject?.layers
+            ?.find(layer => layer.pages?.some(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery))
+            ?.pages?.flatMap(p => ({ id: p.target, label: p.label })) ?? []
+        }, target)
         this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() }, target)
       })
 


### PR DESCRIPTION
`TPEN_CONTEXT` seems to be the only message posting from /simple-transcription/index.js so the other tools are not loading.  