### PR TITLE
See image in transcription interface even when there are no lines

### DIFF
--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -476,16 +476,26 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
   /**
    * Normalize a W3C/IIIF target value to a canvas URI.
-   * Accepts a string URI, `{ source }`, `{ id }`, or `{ "@id" }` shapes and
-   * strips any IIIF media fragment (`#xywh=...`).
-   * @param {string|object|null|undefined} target
+   * Accepts a string URI, `{ source }` (string or SpecificResource object),
+   * `{ id }`, or `{ "@id" }` shapes — including arrays of any of these — and
+   * strips any IIIF media fragment (`#xywh=...`). Returns null for shapes
+   * that do not yield a string URI.
+   * @param {string|object|Array|null|undefined} target
    * @returns {string|null}
    */
   #extractCanvasID(target) {
     if (!target) return null
+    if (Array.isArray(target)) target = target[0]
     let id = null
-    if (typeof target === 'string') id = target
-    else if (typeof target === 'object') id = target.source ?? target.id ?? target['@id'] ?? null
+    if (typeof target === 'string') {
+      id = target
+    } else if (typeof target === 'object') {
+      const source = target.source
+      const fromSource = typeof source === 'string'
+        ? source
+        : source?.id ?? source?.['@id']
+      id = fromSource ?? target.id ?? target['@id'] ?? null
+    }
     if (typeof id !== 'string' || !id) return null
     return id.split('#')[0]
   }

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -518,7 +518,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       // Resolve the canvas ID from page metadata so the image loads even when
       // the page has zero line annotations. Prefer the AnnotationPage's own
       // target, fall back to the project layer's page target, and only use
-      // the first line's target as a last resort for legacy data.
+      // the first line's target as a last resort.
       let canvasID = this.#extractCanvasID(fetchedPage.target)
         ?? this.#extractCanvasID(projectPage?.target)
 

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -474,6 +474,22 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     })
   }
 
+  /**
+   * Normalize a W3C/IIIF target value to a canvas URI.
+   * Accepts a string URI, `{ source }`, `{ id }`, or `{ "@id" }` shapes and
+   * strips any IIIF media fragment (`#xywh=...`).
+   * @param {string|object|null|undefined} target
+   * @returns {string|null}
+   */
+  #extractCanvasID(target) {
+    if (!target) return null
+    let id = null
+    if (typeof target === 'string') id = target
+    else if (typeof target === 'object') id = target.source ?? target.id ?? target['@id'] ?? null
+    if (typeof id !== 'string' || !id) return null
+    return id.split('#')[0]
+  }
+
   async updateTranscriptionImages(pageID) {
     try {
       // Invalidate in-flight upgrade attempts from a previous page/canvas.
@@ -499,23 +515,30 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
         ? { ...fetchedPage, items: orderPageItemsByColumns(projectPage, fetchedPage).orderedItems }
         : fetchedPage
 
-      // Get the first line to extract canvas info
-      let firstLine = this.#page.items?.[0]
-      if (!firstLine) return
+      // Resolve the canvas ID from page metadata so the image loads even when
+      // the page has zero line annotations. Prefer the AnnotationPage's own
+      // target, fall back to the project layer's page target, and only use
+      // the first line's target as a last resort for legacy data.
+      let canvasID = this.#extractCanvasID(fetchedPage.target)
+        ?? this.#extractCanvasID(projectPage?.target)
 
-      // Get the full line annotation
-      firstLine = await vault.get(firstLine, 'annotation')
-      if (!(firstLine?.body)) {
-        firstLine = await vault.get(firstLine, 'annotation', true)
+      if (!canvasID) {
+        let firstLine = this.#page.items?.[0]
+        if (firstLine) {
+          firstLine = await vault.get(firstLine, 'annotation')
+          if (!(firstLine?.body)) {
+            firstLine = await vault.get(firstLine, 'annotation', true)
+          }
+          canvasID = this.#extractCanvasID(firstLine?.target)
+        }
       }
 
-      // Extract canvas ID from the line's target
-      const target = firstLine.target
-      let canvasID = target
-      if (typeof target === 'string') {
-        canvasID = target.split('#')[0]
-      } else if (target?.source) {
-        canvasID = target.source
+      if (!canvasID) {
+        TPEN.eventDispatcher.dispatch("tpen-toast", {
+          message: "Could not determine canvas for this page.",
+          status: "error"
+        })
+        return
       }
 
       let fetchedCanvas = await vault.getWithFallback(canvasID, 'canvas', TPEN.activeProject?.manifest)


### PR DESCRIPTION
Closes #535.

## Summary

The simple transcription interface (`components/simple-transcription/index.js`) failed to load the page image whenever the AnnotationPage had zero line annotations — a gray broken-image placeholder appeared instead. Adding a single line to the same page made the image render correctly.

## Root cause

`updateTranscriptionImages()` derived the Canvas ID from the first line annotation's `target`. With no lines, the function hit an early `return` before fetching the canvas or setting `imgTop.src` / `imgBottom.src`. The image was never loaded even though the page itself loaded fine.

## Fix

Resolve the Canvas from the AnnotationPage's own metadata, which is what the IIIF/W3C model actually provides:

1. Prefer `fetchedPage.target` (the AnnotationPage's canonical canvas reference).
2. Fall back to `projectPage?.target` (the project layer's page reference, already used elsewhere in the codebase).
3. Last resort: fetch the first line annotation and read its target (preserves legacy behavior for malformed data).

If none resolve, surface a clear error toast (`"Could not determine canvas for this page."`) instead of a silent return.

A small `#extractCanvasID(target)` helper normalizes the shapes seen in the codebase:

- string URI
- `{ source }` (string URI or SpecificResource object with `id` / `@id`)
- `{ id }` / `{ "@id" }`
- single-element arrays of any of the above

It also strips IIIF media fragments (`#xywh=...`).

## Behavior changes

- Empty pages: image now loads; the existing `"This page has no line annotations…"` info toast still fires once via `updateLines()`. No more broken image.
- Populated pages: unchanged — `fetchedPage.target` is the same canvas the lines target, so `adjustImages()` and active-line cropping behave identically.
- Genuinely unresolvable pages: replace silent failure with an error toast.
