### PR TITLE
Standardize TPEN ↔ tool messaging contract

### DIFF
--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -969,10 +969,10 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   /**
    * Resolve each item in `page.items` to a full Annotation via the vault.
    * Vault fetches for AnnotationPages return children as bare `{id, type}`
-   * refs — downstream tools need hydrated targets/selectors/bodies. Returns
-   * a shallow copy of the page with the items array replaced; errors on
-   * individual items fall back to the original ref so partial hydration
-   * still produces a usable payload.
+   * refs — downstream tools that opt into the hydrated payload need hydrated
+   * targets/selectors/bodies. Returns a shallow copy of the page with the
+   * items array replaced; errors on individual items fall back to the
+   * original ref so partial hydration still produces a usable payload.
    */
   async #hydratePageItems(page) {
     if (!Array.isArray(page?.items) || page.items.length === 0) return page
@@ -983,9 +983,62 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     return { ...page, items }
   }
 
-  async #buildTPENContext() {
+  /**
+   * Find the layer page entry that matches the active page in the URL. Used
+   * to source the column ordering and the sibling-page list for the lean
+   * TPEN_CONTEXT payload.
+   */
+  #getActiveLayerPage() {
+    const pageInQuery = TPEN.screen?.pageInQuery
+    if (!pageInQuery) return null
+    return TPEN.activeProject?.layers
+      ?.flatMap(layer => layer.pages || [])
+      .find(p => p.id?.split('/').pop() === pageInQuery) ?? null
+  }
+
+  #getActiveLayerSiblings() {
+    const pageInQuery = TPEN.screen?.pageInQuery
+    if (!pageInQuery) return []
+    const layer = TPEN.activeProject?.layers
+      ?.find(l => l.pages?.some(p => p.id?.split('/').pop() === pageInQuery))
+    return layer?.pages?.map(p => ({ id: p.target, label: p.label })) ?? []
+  }
+
+  /**
+   * Lean boot payload sent to every iframe tool on load. Carries identity
+   * fields and URIs only — tools that need annotation bodies should fetch
+   * `annotationPage` directly, and tools that need the fully-hydrated
+   * project/page/canvas objects should send `REQUEST_HYDRATED_CONTEXT`.
+   */
+  #buildTPENContext() {
+    const project = TPEN.activeProject ?? null
+    const layerPage = this.#getActiveLayerPage()
     return {
       type: 'TPEN_CONTEXT',
+      project: project ? {
+        id: project._id ?? project.id ?? null,
+        label: project.label ?? null,
+        slug: project.slug ?? null
+      } : null,
+      manifest: project?.manifest?.[0] ?? null,
+      canvas: this.#canvas?.id ?? this.#canvas?.['@id'] ?? null,
+      annotationPage: this.#page?.id ?? null,
+      currentLineId: this.#getCurrentLineId(),
+      columns: layerPage?.columns ?? [],
+      siblings: this.#getActiveLayerSiblings()
+    }
+  }
+
+  /**
+   * Heavy payload sent only in reply to `REQUEST_HYDRATED_CONTEXT`. Carries
+   * the full active project, the hydrated page (items resolved to full
+   * Annotations via the vault), and the full canvas object. TPEN-Prompts
+   * needs this for prompt-template rendering; most tools should use the
+   * lean `TPEN_CONTEXT` instead.
+   */
+  async #buildHydratedTPENContext() {
+    return {
+      type: 'TPEN_HYDRATED_CONTEXT',
       project: TPEN.activeProject ?? null,
       page: await this.#hydratePageItems(this.#page),
       canvas: this.#canvas ?? null,
@@ -998,10 +1051,15 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     targetWindow.postMessage(message, this._iframeOrigin)
   }
 
-  async #sendTPENContextToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
-    this.#postToTool(await this.#buildTPENContext(), targetWindow)
+  #sendTPENContextToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
+    this.#postToTool(this.#buildTPENContext(), targetWindow)
   }
 
+  // The TPEN ID token is the most sensitive message in this protocol. It is
+  // user-gated (only sent in reply to REQUEST_TPEN_ID_TOKEN), posted to the
+  // iframe origin only, and surfaced via a toast so the user always sees the
+  // grant. Do not send it unprompted, broadcast it with targetOrigin '*', or
+  // log it.
   #sendIdTokenToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
     const idToken = TPEN.getAuthorization()
 
@@ -1095,37 +1153,11 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       this._iframeOrigin = new URL(tool.url).origin
 
       iframe.addEventListener('load', () => {
-        const target = iframe.contentWindow
-        this.#sendTPENContextToTool(target)
-
-        this.#postToTool({
-          type: 'MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION',
-          manifest: TPEN.activeProject?.manifest?.[0] ?? '',
-          canvas: this.#canvas?.id ?? this.#canvas?.['@id'] ?? '',
-          annotationPage: this.#page?.id ?? '',
-          annotation: TPEN.activeLineIndex >= 0
-            ? this.#page?.items?.[TPEN.activeLineIndex]?.id ?? null
-            : null,
-          columns: TPEN.activeProject?.layers
-            ?.flatMap(layer => layer.pages || [])
-            .find(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery)?.columns || []
-        }, target)
-
-        this.#postToTool({
-          type: 'CANVASES',
-          canvases: TPEN.activeProject?.layers
-            ?.find(layer => layer.pages?.some(p => p.id?.split('/').pop() === TPEN.screen?.pageInQuery))
-            ?.pages?.flatMap(p => ({ id: p.target, label: p.label })) ?? []
-        }, target)
-
-        this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: this.#getCurrentLineId() }, target)
+        this.#sendTPENContextToTool(iframe.contentWindow)
       })
 
       const sendLineSelection = () => {
-        const currentLineId = this.#getCurrentLineId()
-        this.#postToTool({ type: 'UPDATE_CURRENT_LINE', currentLineId })
-
-        this.#postToTool({ type: 'CURRENT_LINE_INDEX', lineId: currentLineId })
+        this.#postToTool({ type: 'UPDATE_CURRENT_LINE', currentLineId: this.#getCurrentLineId() })
       }
       this.#toolCleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-previous-line', sendLineSelection)
       this.#toolCleanup.onEvent(TPEN.eventDispatcher, 'tpen-transcription-next-line', sendLineSelection)
@@ -1143,35 +1175,32 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     this.checkMagnifierVisibility?.()
   }
 
-  #handleToolMessages(event) {
+  async #handleToolMessages(event) {
     // Validate message origin if iframe origin is set
     if (this._iframeOrigin && event.origin !== this._iframeOrigin) {
       return
     }
 
-    if (event.data?.type === 'REQUEST_TPEN_ID_TOKEN') {
+    const type = event.data?.type
+    if (!type) return
+
+    if (type === 'REQUEST_TPEN_ID_TOKEN') {
       this.#sendIdTokenToTool(event.source)
       return
     }
-    
-    // Handle incoming messages from tools
-    const lineId = event.data?.lineId ?? event.data?.lineid ?? event.data?.annotation // handle different casing and properties
 
-    if (!lineId) return
+    if (type === 'REQUEST_HYDRATED_CONTEXT') {
+      this.#postToTool(await this.#buildHydratedTPENContext(), event.source)
+      return
+    }
 
-    // Handle all line navigation message types
-    if (event.data?.type === "CURRENT_LINE_INDEX" || 
-        event.data?.type === "RETURN_LINE_ID" || 
-        event.data?.type === "SELECT_ANNOTATION" ||
-        event.data?.type === "NAVIGATE_TO_LINE") {
-      // Tool is telling us to navigate to a specific line
-      // Line ID might be full URI or just the ID part
+    if (type === 'NAVIGATE_TO_LINE') {
+      const lineId = event.data?.lineId
+      if (!lineId) return
       const lineIndex = this.#page?.items?.findIndex(item => {
         const itemId = item.id ?? item['@id']
-        // Match either full ID or just the last part after the last slash
         return itemId === lineId || itemId?.endsWith?.(`/${lineId}`) || itemId?.split?.('/').pop() === lineId
       })
-      
       if (lineIndex !== undefined && lineIndex !== -1) {
         TPEN.activeLineIndex = lineIndex
         this.updateLines()

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -1198,32 +1198,36 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     const type = event.data?.type
     if (!type) return
 
-    if (type === 'REQUEST_TPEN_ID_TOKEN') {
-      this.#sendIdTokenToTool(event.source)
-      return
-    }
-
-    if (type === 'REQUEST_POPULATED_PROJECT') {
-      this.#postToTool(this.#buildPopulatedProject(), event.source)
-      return
-    }
-
-    if (type === 'REQUEST_POPULATED_PAGE') {
-      this.#postToTool(await this.#buildPopulatedPage(), event.source)
-      return
-    }
-
-    if (type === 'NAVIGATE_TO_LINE') {
-      const lineId = event.data?.lineId
-      if (!lineId) return
-      const lineIndex = this.#page?.items?.findIndex(item => {
-        const itemId = item.id ?? item['@id']
-        return itemId === lineId || itemId?.endsWith?.(`/${lineId}`) || itemId?.split?.('/').pop() === lineId
-      })
-      if (lineIndex !== undefined && lineIndex !== -1) {
-        TPEN.activeLineIndex = lineIndex
-        this.updateLines()
+    try {
+      if (type === 'REQUEST_TPEN_ID_TOKEN') {
+        this.#sendIdTokenToTool(event.source)
+        return
       }
+
+      if (type === 'REQUEST_POPULATED_PROJECT') {
+        this.#postToTool(this.#buildPopulatedProject(), event.source)
+        return
+      }
+
+      if (type === 'REQUEST_POPULATED_PAGE') {
+        this.#postToTool(await this.#buildPopulatedPage(), event.source)
+        return
+      }
+
+      if (type === 'NAVIGATE_TO_LINE') {
+        const lineId = event.data?.lineId
+        if (!lineId) return
+        const lineIndex = this.#page?.items?.findIndex(item => {
+          const itemId = item.id ?? item['@id']
+          return itemId === lineId || itemId?.endsWith?.(`/${lineId}`) || itemId?.split?.('/').pop() === lineId
+        })
+        if (lineIndex !== undefined && lineIndex !== -1) {
+          TPEN.activeLineIndex = lineIndex
+          this.updateLines()
+        }
+      }
+    } catch (err) {
+      console.error(`[simple-transcription] tool message handler threw on type=${type}`, err)
     }
   }
 }

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -1009,6 +1009,12 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
    * fields and URIs only — tools that need annotation bodies should fetch
    * `annotationPage` directly, and tools that need the fully-hydrated
    * project/page/canvas objects should send `REQUEST_HYDRATED_CONTEXT`.
+   *
+   * Note: each entry in `siblings` is `{ id, label }` where `id` is the
+   * **canvas IRI** for that sibling page (i.e. `page.target`), not the page
+   * IRI itself. This matches Compare-Pages' usage (it fetches the IRI as a
+   * IIIF canvas). Tools that need the page id should derive it from the
+   * canvas IRI or request the hydrated payload.
    */
   #buildTPENContext() {
     const project = TPEN.activeProject ?? null

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -985,7 +985,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
   /**
    * Find the layer page entry that matches the active page in the URL. Used
-   * to source the column ordering and the sibling-page list for the lean
+   * to source the column ordering and the canvas list for the lean
    * TPEN_CONTEXT payload.
    */
   #getActiveLayerPage() {
@@ -996,7 +996,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       .find(p => p.id?.split('/').pop() === pageInQuery) ?? null
   }
 
-  #getActiveLayerSiblings() {
+  #getActiveLayerCanvases() {
     const pageInQuery = TPEN.screen?.pageInQuery
     if (!pageInQuery) return []
     const layer = TPEN.activeProject?.layers
@@ -1007,14 +1007,15 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   /**
    * Lean boot payload sent to every iframe tool on load. Carries identity
    * fields and URIs only — tools that need annotation bodies should fetch
-   * `annotationPage` directly, and tools that need the fully-hydrated
-   * project/page/canvas objects should send `REQUEST_HYDRATED_CONTEXT`.
+   * `annotationPage` directly, and tools that need the fully-populated
+   * project or page should send `REQUEST_POPULATED_PROJECT` /
+   * `REQUEST_POPULATED_PAGE`.
    *
-   * Note: each entry in `siblings` is `{ id, label }` where `id` is the
-   * **canvas IRI** for that sibling page (i.e. `page.target`), not the page
-   * IRI itself. This matches Compare-Pages' usage (it fetches the IRI as a
-   * IIIF canvas). Tools that need the page id should derive it from the
-   * canvas IRI or request the hydrated payload.
+   * Note: each entry in `canvases` is `{ id, label }` where `id` is the
+   * **canvas IRI** for that page (i.e. `page.target`), not the page IRI
+   * itself. This matches Compare-Pages' usage (it fetches the IRI as a IIIF
+   * canvas). Tools that need the page id should derive it from the canvas
+   * IRI or request the populated page.
    */
   #buildTPENContext() {
     const project = TPEN.activeProject ?? null
@@ -1031,21 +1032,32 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       annotationPage: this.#page?.id ?? null,
       currentLineId: this.#getCurrentLineId(),
       columns: layerPage?.columns ?? [],
-      siblings: this.#getActiveLayerSiblings()
+      canvases: this.#getActiveLayerCanvases()
     }
   }
 
   /**
-   * Heavy payload sent only in reply to `REQUEST_HYDRATED_CONTEXT`. Carries
-   * the full active project, the hydrated page (items resolved to full
-   * Annotations via the vault), and the full canvas object. TPEN-Prompts
-   * needs this for prompt-template rendering; most tools should use the
-   * lean `TPEN_CONTEXT` instead.
+   * Reply payload for `REQUEST_POPULATED_PROJECT`. Carries the full active
+   * project (layers, pages, columns, members, …). Lean `TPEN_CONTEXT` only
+   * carries project identity, so tools that need the full graph must ask
+   * for it explicitly.
    */
-  async #buildHydratedTPENContext() {
+  #buildPopulatedProject() {
     return {
-      type: 'TPEN_HYDRATED_CONTEXT',
-      project: TPEN.activeProject ?? null,
+      type: 'TPEN_POPULATED_PROJECT',
+      project: TPEN.activeProject ?? null
+    }
+  }
+
+  /**
+   * Reply payload for `REQUEST_POPULATED_PAGE`. Carries the active page
+   * with items resolved to full Annotations via the vault, the full canvas
+   * object, and the current line id. TPEN-Prompts uses this for
+   * prompt-template rendering.
+   */
+  async #buildPopulatedPage() {
+    return {
+      type: 'TPEN_POPULATED_PAGE',
       page: await this.#hydratePageItems(this.#page),
       canvas: this.#canvas ?? null,
       currentLineId: this.#getCurrentLineId()
@@ -1055,10 +1067,6 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
   #postToTool(message, targetWindow = this.#activeToolIframe?.contentWindow) {
     if (!this._iframeOrigin || !targetWindow) return
     targetWindow.postMessage(message, this._iframeOrigin)
-  }
-
-  #sendTPENContextToTool(targetWindow = this.#activeToolIframe?.contentWindow) {
-    this.#postToTool(this.#buildTPENContext(), targetWindow)
   }
 
   // The TPEN ID token is the most sensitive message in this protocol. It is
@@ -1159,7 +1167,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       this._iframeOrigin = new URL(tool.url).origin
 
       iframe.addEventListener('load', () => {
-        this.#sendTPENContextToTool(iframe.contentWindow)
+        this.#postToTool(this.#buildTPENContext(), iframe.contentWindow)
       })
 
       const sendLineSelection = () => {
@@ -1195,8 +1203,13 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       return
     }
 
-    if (type === 'REQUEST_HYDRATED_CONTEXT') {
-      this.#postToTool(await this.#buildHydratedTPENContext(), event.source)
+    if (type === 'REQUEST_POPULATED_PROJECT') {
+      this.#postToTool(this.#buildPopulatedProject(), event.source)
+      return
+    }
+
+    if (type === 'REQUEST_POPULATED_PAGE') {
+      this.#postToTool(await this.#buildPopulatedPage(), event.source)
       return
     }
 

--- a/components/transcription-block/index.js
+++ b/components/transcription-block/index.js
@@ -155,16 +155,11 @@ export default class TranscriptionBlock extends HTMLElement {
             if (typeof index === 'number') this.scheduleLineSave(index)
         })
 
-        // Window message handler for external tool communication
+        // Window message handler for external tool communication. Line
+        // navigation is owned by simple-transcription; this listener only
+        // handles UPDATE_LINE_TEXT (e.g. Line-Breaking, Preview-Transcription
+        // pushing edited line text into the active transcription block).
         this.renderCleanup.onWindow('message', (event) => {
-            if (event.data?.type === "RETURN_LINE_ID") {
-                const lineIndex = this.#page.items.findIndex(item => item.id === event.data.lineId)
-                if (lineIndex !== -1) {
-                    this.moveToLine(lineIndex, 'next')
-                    this.updateTranscriptionUI()
-                }
-            }
-
             if (event.data?.type === "UPDATE_LINE_TEXT") {
                 if (typeof event.data.lineIndex === 'number') {
                     this.shadowRoot.querySelector('.transcription-input').value = event.data.text


### PR DESCRIPTION
## Summary

Standardize the postMessage contract between TPEN Interfaces and the splitscreen tools so there is one canonical message per direction, no alias soup, and lean default boot payloads. Also rides along with CenterForDigitalHumanities/TPEN-services#519, which fixes the broken Line History tool URL.

## Canonical contract

### Parent → Tool

- **`TPEN_CONTEXT`** — single boot message on iframe load. Lean payload:

  ```js
  {
    type: 'TPEN_CONTEXT',
    project: { id, label, slug },     // identity only
    manifest: '<URI>',
    canvas: '<URI>',
    annotationPage: '<URI>',
    currentLineId: '<URI|null>',
    columns: [...],                    // active layer's column ordering
    canvases: [{ id, label }, ...]     // pages in the active layer — `id` is the canvas IRI
  }
  ```

  Tools that need annotation bodies should `fetch(annotationPage)` themselves — the parent no longer ships every line over postMessage.

  **`canvas` vs `canvases`** — these answer different questions and most tools read only one of them:
  - `canvas` is *what the user is currently working on* (single URI). Page-Viewer paints this image, Preview-Transcription scopes its line list to it, Line-Breaking edits within it. Tools that don't care about the layer read this and ignore the rest.
  - `canvases` is *what the user could compare to* (list). Only Compare-Pages reads it, to populate its dropdown. The active canvas is included so the dropdown has a label for "you are here" — matches the legacy `CANVASES` shape this replaces.

  In a single-page layer they coincide; in a multi-page layer they diverge.

- **`TPEN_POPULATED_PROJECT`** — sent only in reply to `REQUEST_POPULATED_PROJECT`. Carries the full active project (layers, pages, columns, members).

- **`TPEN_POPULATED_PAGE`** — sent only in reply to `REQUEST_POPULATED_PAGE`. Carries the active page with items resolved to full Annotations via the vault, the full canvas object, and `currentLineId`.

  These two replies replace the earlier combined `TPEN_HYDRATED_CONTEXT`. Splitting them makes each message's projection match its name (you ask for a populated *project*, you get the project; same for the page) instead of one envelope with a mismatched grab-bag shape. TPEN-Prompts requests both on boot and renders templates once both have arrived.

- **`UPDATE_CURRENT_LINE`** — single line-nav delta. `{ currentLineId }`.

- **`TPEN_ID_TOKEN`** — preserved unchanged. User-gated, posted to iframe origin only, with toast confirmation. Most sensitive message in the protocol — explicitly flagged in code with a defensive comment.

### Tool → Parent

- **`REQUEST_POPULATED_PROJECT`** — opt into the full active project.
- **`REQUEST_POPULATED_PAGE`** — opt into the populated page + canvas.
- **`REQUEST_TPEN_ID_TOKEN`** — request the token (parent gates).
- **`NAVIGATE_TO_LINE`** — `{ lineId }`. Single canonical name. Intentionally narrow — when tools need other line verbs (highlight, flag, delete, …), each will be added as its own well-defined message rather than overloading this one.
- **`UPDATE_LINE_TEXT`** — `{ lineIndex, text }`. Unchanged.

### Removed

`MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION`, `CANVAS_ANNOTATIONPAGE_ANNOTATION`, `MANIFEST_CANVAS_ANNOTATIONPAGE`, `CANVAS_ANNOTATIONPAGE`, `MANIFEST_CANVAS`, `CANVAS`, `CANVASES`, `CURRENT_LINE_INDEX`, `SELECT_ANNOTATION`, `RETURN_LINE_ID`.

## Changes in this repo

- `components/simple-transcription/index.js`
  - Lean `#buildTPENContext()` produces the new boot payload. New helpers `#getActiveLayerPage()` and `#getActiveLayerCanvases()` source columns and the canvas list from the active layer.
  - New `#buildPopulatedProject()` and async `#buildPopulatedPage()` return the two split reply payloads. The Promise.allSettled hydration logic lives on the page reply (where it belongs).
  - Iframe `load` handler reduced from four messages to one (`TPEN_CONTEXT`), and now calls `#postToTool(this.#buildTPENContext(), iframe.contentWindow)` directly — the prior `#sendTPENContextToTool` wrapper added a redundant default arg with no clarity gain.
  - `sendLineSelection` posts only `UPDATE_CURRENT_LINE`.
  - `#handleToolMessages` accepts only `REQUEST_TPEN_ID_TOKEN`, `REQUEST_POPULATED_PROJECT`, `REQUEST_POPULATED_PAGE`, `NAVIGATE_TO_LINE`. Alias soup removed.
  - Defensive comment above `#sendIdTokenToTool` flagging the token as the most sensitive message.
  - JSDoc on `#buildTPENContext` clarifies that `canvases[i].id` is the canvas IRI (`page.target`), not the page IRI — matches Compare-Pages' usage.
- `components/transcription-block/index.js`
  - Removed `RETURN_LINE_ID` branch — line nav is owned by `simple-transcription` now. `UPDATE_LINE_TEXT` branch kept (drives `markLineDirty` / `scheduleLineSave` / `persistDraft`).

## Coordinated cut

Hard cut — no dual-accept path. All PRs must merge together to avoid a broken intermediate state.

- TPEN-interfaces (this PR): https://github.com/CenterForDigitalHumanities/TPEN-interfaces/pull/564
- TPEN-services: https://github.com/CenterForDigitalHumanities/TPEN-services/pull/519
- Page-Viewer: https://github.com/CenterForDigitalHumanities/Page-Viewer/pull/14
- Preview-Transcription: https://github.com/CenterForDigitalHumanities/Preview-Transcription/pull/6
- Line-Breaking: https://github.com/CenterForDigitalHumanities/Line-Breaking/pull/2
- Compare-Pages: https://github.com/CenterForDigitalHumanities/Compare-Pages/pull/3
- TPEN-Prompts: https://github.com/CenterForDigitalHumanities/TPEN-Prompts/pull/16

`tpen-line-history` and `cappelli` need no code change — `tpen-line-history` is unblocked solely by the Tools.js URL fix in CenterForDigitalHumanities/TPEN-services#519.

## Test plan

Developer-validated locally on 2026-05-08 (services on `:3012`, interfaces on `:4000`, tool iframes served from `:8080`):

- [x] `jekyll s` in tpen3-interfaces, open `/transcribe` against a project that has each tool added.
- [x] Page-Viewer renders the canvas image immediately on iframe load and highlights the active line on `UPDATE_CURRENT_LINE`. Race-fix `ff25235` confirmed — overlay is highlighted on first paint, no click required.
- [x] Preview-Transcription lists all lines and reflects the active line on `UPDATE_CURRENT_LINE`.
- [x] Line-Breaking edits a line and the transcription-block receives `UPDATE_LINE_TEXT`.
- [x] Compare-Pages populates its dropdown from `TPEN_CONTEXT.canvases` (single-page test project — multi-page exercise covered by #566).
- [x] TPEN-Prompts boots, posts `REQUEST_POPULATED_PROJECT` and `REQUEST_POPULATED_PAGE`, receives `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE`, renders templates once both arrive; consent button produces a token. Standalone mode (`?projectID=...`) also boots.
- [x] History Tool loads (no 404 in console) — script returns 200 from the new GitHub Pages URL. Live-line tracking on local stack is gated on CenterForDigitalHumanities/tpen-line-history#5 (hardcoded prod TPEN module URL); works on prod where module URLs dedupe.
- [x] DevTools: exactly one parent-origin `postMessage` per iframe load (`TPEN_CONTEXT`) and one per line navigation (`UPDATE_CURRENT_LINE`). For TPEN-Prompts, exactly two additional request/reply pairs on boot (`REQUEST_POPULATED_PROJECT` → `TPEN_POPULATED_PROJECT`, `REQUEST_POPULATED_PAGE` → `TPEN_POPULATED_PAGE`). Negative-presence verified across all 5 iframe tools — no legacy `MANIFEST_CANVAS_*`, `CANVASES`, `CURRENT_LINE_INDEX`, `SELECT_ANNOTATION`, or `RETURN_LINE_ID` traffic.
- [x] The lean `TPEN_CONTEXT` payload contains only the documented fields (no full project, no hydrated items). The populated replies only ship to the tool that requested them (only TPEN-Prompts).
- [x] `npm run allTests` in tpen3-services passes — 187/187 ✅ (113 integration tests skipped, as expected without a live test stack).

## Companion follow-ups (deferred, do not block this cut)

Issues filed during local-stack testing for pre-existing gaps that were *not* introduced by this PR:

- #565 + CenterForDigitalHumanities/Preview-Transcription#7 — broadcast parent-side line-text edits to active tool iframes (new optional `LINE_TEXT_UPDATED` message).
- #566 — broaden `TPEN_CONTEXT.canvases` to span all layers (legacy `CANVASES` was also single-layer; this faithfully ports that constraint).
- CenterForDigitalHumanities/tpen-line-history#5 — hardcoded `https://app.t-pen.org/api/TPEN.js` import prevents local-stack and dev-stack testing.

## Review responses

Address-by-address response to @cubap's first review pass:

1. **`siblings` was misnamed** — agreed. Renamed to `canvases` across the parent payload, the helper (`#getActiveLayerCanvases`), Compare-Pages' consumer, and #566's body. The list contains pages-as-canvases (each entry's `id` is `page.target`, the canvas IRI), so the new name describes the contents directly.
2. **`TPEN_HYDRATED_CONTEXT` projection mismatched its name** — agreed. Split into `REQUEST_POPULATED_PROJECT` / `REQUEST_POPULATED_PAGE` with matching `TPEN_POPULATED_PROJECT` / `TPEN_POPULATED_PAGE` replies. Each message's shape now matches its name. TPEN-Prompts' MessageHandler accumulates the two halves and calls `acceptContext` once both have arrived.
3. **`#sendTPENContextToTool` wrapper was redundant** — agreed. Inlined; the iframe-load handler now calls `this.#postToTool(this.#buildTPENContext(), iframe.contentWindow)` directly.
4. **canvas-panel listener** — `components/transcription-canvas-panel/index.js` is orphaned (no longer instantiated; flagged in the plan as out of scope). Left alone here; eventual removal tracked separately from this contract cut.
5. **Other line verbs (highlight, act-on)** — kept `NAVIGATE_TO_LINE` intentionally narrow. New verbs (e.g. `HIGHLIGHT_LINE`, `FLAG_LINE`) will be added as concrete needs arise rather than designing speculative envelopes now. Noted in the contract section above.
6. **transcription-block: NAVIGATE here, or watch `TPEN.screen.activeLine`?** — agreed this is the right architectural question, but a follow-up. The current cut centralizes all line-nav in `simple-transcription` so the protocol has a single owner; refactoring to a global `TPEN.screen.activeLine` subscription would be a separate piece of work.

## Out of scope

- Origin-gating tightening on tool message listeners (tracked separately).
- `components/transcription-canvas-panel/index.js` (orphaned but left alone).