### PR TITLE
Keep Transcription Workspace On Screen

### DIFF
--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -418,13 +418,16 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
       }
     })
 
-    // Keep #imgTop bounded by whatever space the workspace currently uses (issue #551).
-    // Workspace height changes when tools open/close, so observe it live instead of
-    // using a fixed CSS reserve.
+    // Keep #imgTop bounded by whatever space the workspace currently uses.
+    // Workspace height changes when tools open/close, and .image-container height
+    // can change when the project header grows/shrinks, so observe both live
+    // instead of using a fixed CSS reserve.
     const workspaceEl = this.shadowRoot.querySelector('#transWorkspace')
-    if (workspaceEl && typeof ResizeObserver !== 'undefined') {
+    const containerEl = this.shadowRoot.querySelector('.image-container')
+    if (typeof ResizeObserver !== 'undefined' && (workspaceEl || containerEl)) {
       const observer = new ResizeObserver(() => this.#updateImgTopMaxHeight())
-      observer.observe(workspaceEl)
+      if (workspaceEl) observer.observe(workspaceEl)
+      if (containerEl) observer.observe(containerEl)
       this.renderCleanup.add(() => observer.disconnect())
     }
   }
@@ -442,7 +445,8 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     const containerHeight = imageContainer.clientHeight || globalThis.innerHeight || 0
     const workspaceHeight = workspace.offsetHeight || 0
     const MIN_BOTTOM_PREVIEW = 40
-    const available = Math.max(containerHeight - workspaceHeight - MIN_BOTTOM_PREVIEW, 120)
+    const MIN_IMGTOP_HEIGHT = 120
+    const available = Math.max(containerHeight - workspaceHeight - MIN_BOTTOM_PREVIEW, MIN_IMGTOP_HEIGHT)
     imgTop.style.maxHeight = `${available}px`
   }
 

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -119,6 +119,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
 
   handleResize() {
     // Recalculate image positions on resize
+    this.#updateImgTopMaxHeight()
     if (this.#activeLine) {
       this.adjustImages(this.#activeLine)
     }
@@ -263,7 +264,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
           height: 0px;
           width: 100%;
           overflow: hidden;
-          transition: height 0.5s ease-in-out;
+          transition: height 0.5s ease-in-out, max-height 0.2s ease-in-out;
           background-color: #1a1a1a;
         }
         
@@ -416,6 +417,33 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
         this.updateLines()
       }
     })
+
+    // Keep #imgTop bounded by whatever space the workspace currently uses (issue #551).
+    // Workspace height changes when tools open/close, so observe it live instead of
+    // using a fixed CSS reserve.
+    const workspaceEl = this.shadowRoot.querySelector('#transWorkspace')
+    if (workspaceEl && typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(() => this.#updateImgTopMaxHeight())
+      observer.observe(workspaceEl)
+      this.renderCleanup.add(() => observer.disconnect())
+    }
+  }
+
+  /**
+   * Cap #imgTop's height so a tall line cannot push #transWorkspace off-screen.
+   * Reserves the live-measured workspace height plus a small strip for #imgBottom.
+   */
+  #updateImgTopMaxHeight() {
+    const imgTop = this.shadowRoot.querySelector('#imgTop')
+    const workspace = this.shadowRoot.querySelector('#transWorkspace')
+    const imageContainer = this.shadowRoot.querySelector('.image-container')
+    if (!imgTop || !workspace || !imageContainer) return
+
+    const containerHeight = imageContainer.clientHeight || globalThis.innerHeight || 0
+    const workspaceHeight = workspace.offsetHeight || 0
+    const MIN_BOTTOM_PREVIEW = 40
+    const available = Math.max(containerHeight - workspaceHeight - MIN_BOTTOM_PREVIEW, 120)
+    imgTop.style.maxHeight = `${available}px`
   }
 
   toggleSplitscreen() {

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -264,7 +264,7 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
           height: 0px;
           width: 100%;
           overflow: hidden;
-          transition: height 0.5s ease-in-out, max-height 0.2s ease-in-out;
+          transition: height 0.5s ease-in-out;
           background-color: #1a1a1a;
         }
         

--- a/components/simple-transcription/index.js
+++ b/components/simple-transcription/index.js
@@ -419,15 +419,12 @@ export default class SimpleTranscriptionInterface extends HTMLElement {
     })
 
     // Keep #imgTop bounded by whatever space the workspace currently uses.
-    // Workspace height changes when tools open/close, and .image-container height
-    // can change when the project header grows/shrinks, so observe both live
-    // instead of using a fixed CSS reserve.
+    // Workspace height changes when tools open/close; .image-container is pinned
+    // at 100vh and only changes on window resize, which handleResize already covers.
     const workspaceEl = this.shadowRoot.querySelector('#transWorkspace')
-    const containerEl = this.shadowRoot.querySelector('.image-container')
-    if (typeof ResizeObserver !== 'undefined' && (workspaceEl || containerEl)) {
+    if (typeof ResizeObserver !== 'undefined' && workspaceEl) {
       const observer = new ResizeObserver(() => this.#updateImgTopMaxHeight())
-      if (workspaceEl) observer.observe(workspaceEl)
-      if (containerEl) observer.observe(containerEl)
+      observer.observe(workspaceEl)
       this.renderCleanup.add(() => observer.disconnect())
     }
   }


### PR DESCRIPTION
## Summary

Fixes [#551](https://github.com/CenterForDigitalHumanities/TPEN-interfaces/issues/551) — a transcription line that boxes a tall region (a full un-split column, a tall decoration, etc.) was sizing `#imgTop` so large that `#transWorkspace` and the `#imgBottom` preview got pushed below the viewport. Body is `overflow: hidden`, so the editor for the active line became unreachable.

## What changed

`components/simple-transcription/index.js`

- Added `#updateImgTopMaxHeight()` — caps `#imgTop`'s `max-height` to `imageContainer.clientHeight - workspaceHeight - 40px`, floored at 120px so we never collapse it on weird layouts.
- Hooked it up two ways:
  - `ResizeObserver` on `#transWorkspace` so the cap recomputes whenever tools open/close change the workspace's height.
  - `handleResize()` now calls it as well, so viewport resizes pick up the new `.image-container` height (pinned at 100vh).
- Observer is registered with `renderCleanup` so it disconnects on re-render / disconnect.

No changes to canvas-panel rendering, zoom math, or the line-overlay alignment — `#imgTop` keeps its natural sizing from `adjustImages()` and is only clamped at the top end via `max-height`.
